### PR TITLE
Module Dependencies

### DIFF
--- a/activitytype-cql/pom.xml
+++ b/activitytype-cql/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../mvn-defaults</relativePath>
     </parent>
 
-    <artifactId>at-cql</artifactId>
+    <artifactId>activitytype-cql</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 

--- a/activitytype-cqlverify/pom.xml
+++ b/activitytype-cqlverify/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../mvn-defaults</relativePath>
   </parent>
 
-  <artifactId>at-cqlverify</artifactId>
+  <artifactId>activitytype-cqlverify</artifactId>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
 
@@ -23,7 +23,7 @@
 
     <dependency>
       <groupId>io.nosqlbench</groupId>
-      <artifactId>at-cql</artifactId>
+      <artifactId>activitytype-cql</artifactId>
       <version>3.12.2-SNAPSHOT</version>
     </dependency>
 

--- a/nb/pom.xml
+++ b/nb/pom.xml
@@ -69,6 +69,19 @@
             <version>3.12.2-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.nosqlbench</groupId>
+            <artifactId>activitytype-cql</artifactId>
+            <version>3.12.2-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.nosqlbench</groupId>
+            <artifactId>activitytype-cqlverify</artifactId>
+            <version>3.12.2-SNAPSHOT</version>
+        </dependency>
+
+
         <!--        <dependency>-->
 <!--            <groupId>io.nosqlbench</groupId>-->
 <!--            <artifactId>nb-runtime</artifactId>-->


### PR DESCRIPTION
Include cql activitytypes in poms. Use `activitytype-` artifact prefix