### PR TITLE
[issue-58] Rename one of the conflicting exception classes

### DIFF
--- a/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/core/CqlAction.java
+++ b/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/core/CqlAction.java
@@ -7,7 +7,7 @@ import io.nosqlbench.activitytype.cql.api.RowCycleOperator;
 import io.nosqlbench.activitytype.cql.api.StatementFilter;
 import io.nosqlbench.activitytype.cql.errorhandling.ErrorStatus;
 import io.nosqlbench.activitytype.cql.errorhandling.HashedCQLErrorHandler;
-import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleException;
+import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleWithStatementException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.ChangeUnappliedCycleException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.MaxTriesExhaustedException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.UnexpectedPagingException;
@@ -221,7 +221,7 @@ public class CqlAction implements SyncAction, MultiPhaseAction, ActivityDefObser
                     long resultNanos = resultTime.stop();
                     resultTime = null;
                     readyCQLStatement.onError(cycleValue, resultNanos, e);
-                    CQLCycleException cqlCycleException = new CQLCycleException(cycleValue, resultNanos, e, readyCQLStatement);
+                    CQLCycleWithStatementException cqlCycleException = new CQLCycleWithStatementException(cycleValue, resultNanos, e, readyCQLStatement);
                     ErrorStatus errorStatus = ebdseErrorHandler.handleError(cycleValue, cqlCycleException);
                     if (!errorStatus.isRetryable()) {
                         cqlActivity.triesHisto.update(tries);
@@ -313,7 +313,7 @@ public class CqlAction implements SyncAction, MultiPhaseAction, ActivityDefObser
                         resultTime = null;
 
                         pagingReadyStatement.onError(cycleValue, resultNanos, e);
-                        CQLCycleException cqlCycleException = new CQLCycleException(cycleValue, resultNanos, e, pagingReadyStatement);
+                        CQLCycleWithStatementException cqlCycleException = new CQLCycleWithStatementException(cycleValue, resultNanos, e, pagingReadyStatement);
                         ErrorStatus errorStatus = ebdseErrorHandler.handleError(cycleValue, cqlCycleException);
                         if (!errorStatus.isRetryable()) {
                             cqlActivity.triesHisto.update(tries);

--- a/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/core/CqlAsyncAction.java
+++ b/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/core/CqlAsyncAction.java
@@ -9,7 +9,7 @@ import io.nosqlbench.activitytype.cql.api.RowCycleOperator;
 import io.nosqlbench.activitytype.cql.api.StatementFilter;
 import io.nosqlbench.activitytype.cql.errorhandling.ErrorStatus;
 import io.nosqlbench.activitytype.cql.errorhandling.HashedCQLErrorHandler;
-import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleException;
+import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleWithStatementException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.ChangeUnappliedCycleException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.UnexpectedPagingException;
 import io.nosqlbench.activitytype.cql.statements.core.ReadyCQLStatement;
@@ -195,7 +195,7 @@ public class CqlAsyncAction extends BaseAsyncAction<CqlOpData, CqlActivity> {
 
             cqlop.readyCQLStatement.onError(cqlop.cycle, currentServiceTime, e);
 
-            CQLCycleException cqlCycleException = new CQLCycleException(cqlop.cycle, currentServiceTime, e, cqlop.readyCQLStatement);
+            CQLCycleWithStatementException cqlCycleException = new CQLCycleWithStatementException(cqlop.cycle, currentServiceTime, e, cqlop.readyCQLStatement);
             ErrorStatus errorStatus = cqlActivityErrorHandler.handleError(cqlop.cycle, cqlCycleException);
 
             if (errorStatus.isRetryable() && ++cqlop.triesAttempted < maxTries) {
@@ -223,7 +223,7 @@ public class CqlAsyncAction extends BaseAsyncAction<CqlOpData, CqlActivity> {
         cqlop.readyCQLStatement.onError(startedOp.getCycle(),serviceTime,cqlop.throwable);
 
         long cycle = startedOp.getCycle();
-        CQLCycleException cqlCycleException1 = new CQLCycleException(cqlop.cycle, serviceTime, cqlop.throwable, cqlop.readyCQLStatement);
+        CQLCycleWithStatementException cqlCycleException1 = new CQLCycleWithStatementException(cqlop.cycle, serviceTime, cqlop.throwable, cqlop.readyCQLStatement);
         ErrorStatus errorStatus = cqlActivityErrorHandler.handleError(startedOp.getCycle(), cqlCycleException1);
 
         if (errorStatus.getResponse() == ErrorResponse.stop) {

--- a/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/EbdseCycleErrorHandler.java
+++ b/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/EbdseCycleErrorHandler.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.activitytype.cql.errorhandling;
 
 import io.nosqlbench.activitytype.cql.api.ErrorResponse;
-import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleException;
+import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleWithStatementException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLExceptionDetailer;
 import io.nosqlbench.engine.api.activityapi.errorhandling.CycleErrorHandler;
 import io.nosqlbench.engine.api.metrics.ExceptionCountMetrics;
@@ -62,7 +62,7 @@ public class EbdseCycleErrorHandler implements CycleErrorHandler<Throwable, Erro
 
     @Override
     public ErrorStatus handleError(long cycle, Throwable contextError) {
-        CQLCycleException cce = (CQLCycleException) contextError;
+        CQLCycleWithStatementException cce = (CQLCycleWithStatementException) contextError;
         Throwable error = cce.getCause();
 
         boolean retry = false;

--- a/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/HashedCQLErrorHandler.java
+++ b/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/HashedCQLErrorHandler.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.activitytype.cql.errorhandling;
 
 import com.datastax.driver.core.exceptions.*;
-import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleException;
+import io.nosqlbench.activitytype.cql.errorhandling.exceptions.CQLCycleWithStatementException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.ChangeUnappliedCycleException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.ResultSetVerificationException;
 import io.nosqlbench.activitytype.cql.errorhandling.exceptions.RowVerificationException;
@@ -54,8 +54,8 @@ public class HashedCQLErrorHandler extends HashedErrorHandler<Throwable, ErrorSt
     @Override
     public ErrorStatus handleError(long cycle, Throwable throwable, String errMsg) {
         int resultCode = 127;
-        if (throwable instanceof CQLCycleException) {
-            CQLCycleException cce = (CQLCycleException) throwable;
+        if (throwable instanceof CQLCycleWithStatementException) {
+            CQLCycleWithStatementException cce = (CQLCycleWithStatementException) throwable;
             Throwable cause = cce.getCause();
             try {
                 String simpleName = cause.getClass().getSimpleName();

--- a/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/exceptions/CQLCycleWithStatementException.java
+++ b/activitytype-cql/src/main/java/io/nosqlbench/activitytype/cql/errorhandling/exceptions/CQLCycleWithStatementException.java
@@ -6,13 +6,13 @@ import io.nosqlbench.activitytype.cql.statements.core.ReadyCQLStatement;
  * In internal exception type that is used to saverow exception
  * context from within a CQL activity cycle.
  */
-public class CQLCycleException extends Exception {
+public class CQLCycleWithStatementException extends Exception {
 
     private final long cycleValue;
     private final long durationNanos;
     private final ReadyCQLStatement readyCQLStatement;
 
-    public CQLCycleException(long cycleValue, long durationNanos, Throwable e, ReadyCQLStatement readyCQLStatement) {
+    public CQLCycleWithStatementException(long cycleValue, long durationNanos, Throwable e, ReadyCQLStatement readyCQLStatement) {
         super(e);
         this.cycleValue = cycleValue;
         this.durationNanos = durationNanos;


### PR DESCRIPTION
this isn't perfect solution, but at least fixes #58 - in long term we need to review the
existing hierarchy of CQL-related Exception classes