### PR TITLE
use Java 12 everywhere

### DIFF
--- a/docsys/pom.xml
+++ b/docsys/pom.xml
@@ -127,15 +127,6 @@
 
     <build>
         <plugins>
-          <plugin>
-            <!-- TODO: change to Java 12 everywhere? -->
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>12</release>
-                    <source>12</source>
-                    <target>12</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/engine-cli/pom.xml
+++ b/engine-cli/pom.xml
@@ -33,6 +33,13 @@
       <classifier>shaded</classifier>
     </dependency>
 
+    <!-- TODO: do we need this, if we're using shaded variant? -->
+    <dependency>
+      <groupId>io.nosqlbench</groupId>
+      <artifactId>engine-docker</artifactId>
+      <version>3.12.43-SNAPSHOT</version>
+    </dependency>
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -50,14 +57,10 @@
       <artifactId>assertj-core-java8</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.nosqlbench</groupId>
-      <artifactId>engine-docker</artifactId>
-      <version>3.12.43-SNAPSHOT</version>
     </dependency>
 
 

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -11,7 +11,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javadoc.name>nosqlbench</javadoc.name>
 
-        <java.target.version>11</java.target.version>
+        <java.target.version>12</java.target.version>
         
         <!-- properties for package versions -->
         <antlr4.version>4.7.2</antlr4.version>


### PR DESCRIPTION
the `docsys` module did use Java 12 for it, while the rest was compiled for Java 11.  As
we're packing with Java 12 anyway, let switch to it for everything.