### PR TITLE
Better error handling

### DIFF
--- a/engine-core/src/main/java/io/nosqlbench/engine/core/ActivityExecutor.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/ActivityExecutor.java
@@ -20,6 +20,7 @@ import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.activityimpl.ParameterMap;
 import io.nosqlbench.engine.api.activityimpl.SlotStateTracker;
 import io.nosqlbench.engine.api.activityimpl.input.ProgressCapable;
+import io.nosqlbench.nb.api.errors.BasicError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,12 +98,15 @@ public class ActivityExecutor implements ActivityController, ParameterMap.Listen
             activity.setRunState(RunState.Starting);
             activity.initActivity();
             //activity.onActivityDefUpdate(activityDef);
+        } catch (BasicError ue) {
+            logger.error(ue.getMessage());
         } catch (Exception e) {
             this.stoppingException = new RuntimeException("Error initializing activity '" +
                     activity.getAlias() +"': " + e.getMessage(),e);
             activitylogger.error("error initializing activity '" + activity.getAlias() + "': " + stoppingException);
             throw stoppingException;
         }
+
         adjustToActivityDef(activity.getActivityDef());
         activity.setRunState(RunState.Running);
         activitylogger.debug("START/after alias=(" + activity.getAlias() + ")");


### PR DESCRIPTION
Avoids unnecessary stack traces for BasicErrors and improves the message for when the cql errors= parameter uses a bad value:

```
15:49:23.200 [scenarios:001] ERROR i.n.engine.core.ActivityExecutor - Invalid parameter for errors: 'bla' should be one of: stop, warn, retry, histogram, count, ignore
Disconnected from the target VM, address: '127.0.0.1:53239', transport: 'socket'

Process finished with exit code 0
```