### PR TITLE
fixed a docker-metrics bug so grafana can see prom container by default

### DIFF
--- a/engine-cli/src/main/resources/docker/datasources/prometheus-datasource.yaml
+++ b/engine-cli/src/main/resources/docker/datasources/prometheus-datasource.yaml
@@ -1,8 +1,8 @@
 {
   "name":"prometheus",
   "type":"prometheus",
-  "url":"http://localhost:9090",
-  "access":"direct",
+  "url":"http://prom:9090",
+  "access":"proxy",
   "editable":true,
   "basicAuth":false
 }

--- a/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerHelper.java
+++ b/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerHelper.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static io.nosqlbench.engine.docker.RestHelper.post;
 
@@ -45,7 +46,7 @@ public class DockerHelper {
             .withDockerCmdExecFactory(dockerCmdExecFactory)
             .build();
     }
-    public String startDocker(String IMG, String tag, String name, List<Integer> ports, List<String> volumeDescList, List<String> envList, List<String> cmdList, String reload) {
+    public String startDocker(String IMG, String tag, String name, List<Integer> ports, List<String> volumeDescList, List<String> envList, List<String> cmdList, String reload, List<String> linkNames) {
         logger.debug("Starting docker with img=" + IMG + ", tag=" + tag + ", name=" + name + ", " +
             "ports=" + ports + ", volumes=" + volumeDescList + ", env=" + envList + ", cmds=" + cmdList + ", reload=" + reload);
 
@@ -108,6 +109,7 @@ public class DockerHelper {
 
 
         CreateContainerResponse containerResponse;
+        List<Link> links = linkNames.stream().map(x->new Link(x,x)).collect(Collectors.toList());
         if (envList == null) {
             containerResponse = dockerClient.createContainerCmd(IMG + ":" + tag)
                 .withCmd(cmdList)
@@ -120,6 +122,7 @@ public class DockerHelper {
                 )
                 .withName(name)
                 //.withVolumes(volumeList)
+                .withLinks(links)
                 .exec();
         } else {
             long user = new UnixSystem().getUid();
@@ -133,6 +136,7 @@ public class DockerHelper {
                         .withBinds(volumeBindList)
                 )
                 .withName(name)
+                .withLinks(links)
                 .withUser(""+user)
                 //.withVolumes(volumeList)
                 .exec();

--- a/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerMetricsManager.java
+++ b/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerMetricsManager.java
@@ -74,7 +74,9 @@ public class DockerMetricsManager {
         );
 
         String reload = null;
-        String containerId = dh.startDocker(GRAFANA_IMG, tag, name, port, volumeDescList, envList, null, reload);
+        List<String> linkNames = new ArrayList();
+        linkNames.add("prom");
+        String containerId = dh.startDocker(GRAFANA_IMG, tag, name, port, volumeDescList, envList, null, reload, linkNames);
         if (containerId == null){
             return;
         }
@@ -118,7 +120,8 @@ public class DockerMetricsManager {
         );
 
         String reload = "http://localhost:9090/-/reload";
-        dh.startDocker(PROMETHEUS_IMG, tag, name, port, volumeDescList, envList, cmdList, reload);
+        List<String> linkNames = new ArrayList();
+        dh.startDocker(PROMETHEUS_IMG, tag, name, port, volumeDescList, envList, cmdList, reload, linkNames);
 
         logger.info("prometheus started and listenning");
     }
@@ -137,7 +140,8 @@ public class DockerMetricsManager {
         List<String> envList = Arrays.asList();
 
         String reload = null;
-        dh.startDocker(GRAPHITE_EXPORTER_IMG, tag, name, port, volumeDescList, envList, null, reload);
+        List<String> linkNames = new ArrayList();
+        dh.startDocker(GRAPHITE_EXPORTER_IMG, tag, name, port, volumeDescList, envList, null, reload, linkNames);
 
         logger.info("graphite exporter container started");
 


### PR DESCRIPTION
Fixed a docker-metrics bug that prevents grafana started by --docker-metrics on a Linux server from accessing prometheus in another docker container