### PR TITLE
fix WeightedLongs function: member values not allocated

### DIFF
--- a/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/WeightedLongs.java
+++ b/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/WeightedLongs.java
@@ -39,6 +39,7 @@ public class WeightedLongs implements LongFunction<Long> {
 
         String[] fragments = new String[pairs.length];
         List<Double> parsedWeights = new ArrayList<>();
+        values = new long[pairs.length];
         for (int i = 0; i < pairs.length; i++) {
             String[] pair = pairs[i].split(":", 2);
             if (pair.length == 2) {


### PR DESCRIPTION
Allocate memory for member variable values