### PR TITLE
Allow PulsarConsumer to configure a Timeout

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
@@ -38,7 +38,8 @@ public class PulsarConsumerMapper extends PulsarOpMapper {
         return new PulsarConsumerOp(
             consumer,
             clientSpace.getPulsarSchema(),
-            asyncApi
+            asyncApi,
+            clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds()
         );
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -2,33 +2,49 @@ package io.nosqlbench.driver.pulsar.ops;
 
 import io.nosqlbench.driver.pulsar.util.AvroUtil;
 import io.nosqlbench.driver.pulsar.util.PulsarActivityUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.common.schema.SchemaType;
 
+import java.util.concurrent.TimeUnit;
+
 public class PulsarConsumerOp implements PulsarOp {
+
+    private final static Logger logger = LogManager.getLogger(PulsarConsumerOp.class);
+
     private final Consumer<?> consumer;
     private final Schema<?> pulsarSchema;
     private final boolean asyncPulsarOp;
+    private final int timeoutSeconds;
 
-    public PulsarConsumerOp(Consumer<?> consumer, Schema<?> schema, boolean asyncPulsarOp) {
+    public PulsarConsumerOp(Consumer<?> consumer, Schema<?> schema, boolean asyncPulsarOp, int timeoutSeconds) {
         this.consumer = consumer;
         this.pulsarSchema = schema;
         this.asyncPulsarOp = asyncPulsarOp;
+        this.timeoutSeconds = timeoutSeconds;
     }
 
     public void syncConsume() {
         try {
-            Message<?> message = consumer.receive();
+            Message<?> message = consumer.receive(timeoutSeconds, TimeUnit.SECONDS);
+            if (message == null) {
+                throw new RuntimeException("Did not receive a message within "+timeoutSeconds+" seconds");
+            }
 
             SchemaType schemaType = pulsarSchema.getSchemaInfo().getType();
             if (PulsarActivityUtil.isAvroSchemaTypeStr(schemaType.name())) {
-                String avroDefStr = pulsarSchema.getSchemaInfo().getSchemaDefinition();
-                org.apache.avro.generic.GenericRecord avroGenericRecord =
-                    AvroUtil.GetGenericRecord_ApacheAvro(avroDefStr, message.getData());
+                if (logger.isDebugEnabled()) {
+                    String avroDefStr = pulsarSchema.getSchemaInfo().getSchemaDefinition();
+                    org.apache.avro.generic.GenericRecord avroGenericRecord =
+                        AvroUtil.GetGenericRecord_ApacheAvro(avroDefStr, message.getData());
 
-                System.out.println("msg-key=" + message.getKey() + "  msg-payload=" + avroGenericRecord.toString());
+                    logger.debug("msg-key={}  msg-payload={}", message.getKey(), avroGenericRecord.toString());
+                }
             } else {
-                System.out.println("msg-key=" + message.getKey() + "  msg-payload=" + new String(message.getData()));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("msg-key={}  msg-payload={}", message.getKey(), new String(message.getData()));
+                }
             }
 
             consumer.acknowledge(message.getMessageId());

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarNBClientConf.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarNBClientConf.java
@@ -228,6 +228,13 @@ public class PulsarNBClientConf {
         else
             return confValue.toString();
     }
+    public int getConsumerTimeoutSeconds() {
+        Object confValue = getConsumerConfValue("consumer.timeout");
+        if (confValue == null)
+            return 0; // infinite
+        else
+            return Integer.parseInt(confValue.toString());
+    }
     public String getConsumerSubscriptionName() {
         Object confValue = getConsumerConfValue("consumer.subscriptionName");
         if (confValue == null)

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarNBClientConf.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarNBClientConf.java
@@ -231,7 +231,7 @@ public class PulsarNBClientConf {
     public int getConsumerTimeoutSeconds() {
         Object confValue = getConsumerConfValue("consumer.timeout");
         if (confValue == null)
-            return 0; // infinite
+            return -1; // infinite
         else
             return Integer.parseInt(confValue.toString());
     }


### PR DESCRIPTION
Add new consumer.timeout property to fail the test in case of missing records from Pulsar within a given period.
Remove spammy System.out that waste resources and also may slow down the execution