### PR TITLE
Pulsar: add bytes counters

### DIFF
--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-client</artifactId>
+            <artifactId>pulsar-client-original</artifactId>
             <version>${pulsar.version}</version>
         </dependency>
 
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.10.1</version>
+            <version>1.9.1</version>
         </dependency>
 
     </dependencies>

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-client-original</artifactId>
+            <artifactId>pulsar-client</artifactId>
             <version>${pulsar.version}</version>
         </dependency>
 
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.9.1</version>
+            <version>1.10.1</version>
         </dependency>
 
     </dependencies>

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.driver.pulsar;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
 import io.nosqlbench.driver.pulsar.ops.PulsarOp;
 import io.nosqlbench.driver.pulsar.ops.ReadyPulsarOp;
@@ -23,6 +23,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
     public Timer bindTimer;
     public Timer executeTimer;
     public Counter bytesCounter;
+    public Histogram messagesizeHistogram;
     private PulsarSpaceCache pulsarCache;
 
     private PulsarNBClientConf clientConf;
@@ -45,7 +46,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
         bindTimer = ActivityMetrics.timer(activityDef, "bind");
         executeTimer = ActivityMetrics.timer(activityDef, "execute");
         bytesCounter = ActivityMetrics.counter(activityDef, "bytes");
-
+        messagesizeHistogram = ActivityMetrics.histogram(activityDef, "messagesize");
         String pulsarClntConfFile = activityDef.getParams().getOptionalString("config").orElse("config.properties");
         clientConf = new PulsarNBClientConf(pulsarClntConfFile);
 
@@ -94,5 +95,9 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
     public Counter getBytesCounter() {
         return bytesCounter;
+    }
+
+    public Histogram getMessagesizeHistogram() {
+        return messagesizeHistogram;
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -1,5 +1,7 @@
 package io.nosqlbench.driver.pulsar;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import io.nosqlbench.driver.pulsar.ops.PulsarOp;
 import io.nosqlbench.driver.pulsar.ops.ReadyPulsarOp;
@@ -20,6 +22,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
     public Timer bindTimer;
     public Timer executeTimer;
+    public Counter bytesCounter;
     private PulsarSpaceCache pulsarCache;
 
     private PulsarNBClientConf clientConf;
@@ -41,6 +44,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
         bindTimer = ActivityMetrics.timer(activityDef, "bind");
         executeTimer = ActivityMetrics.timer(activityDef, "execute");
+        bytesCounter = ActivityMetrics.counter(activityDef, "bytes");
 
         String pulsarClntConfFile = activityDef.getParams().getOptionalString("config").orElse("config.properties");
         clientConf = new PulsarNBClientConf(pulsarClntConfFile);
@@ -49,7 +53,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
         pulsarCache = new PulsarSpaceCache(this);
 
-        this.sequencer = createOpSequence((ot) -> new ReadyPulsarOp(ot, pulsarCache));
+        this.sequencer = createOpSequence((ot) -> new ReadyPulsarOp(ot, pulsarCache, this));
         setDefaultsFromOpSequence(sequencer);
         onActivityDefUpdate(activityDef);
 
@@ -86,5 +90,9 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
     public Timer getExecuteTimer() {
         return this.executeTimer;
+    }
+
+    public Counter getBytesCounter() {
+        return bytesCounter;
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
@@ -1,5 +1,7 @@
 package io.nosqlbench.driver.pulsar.ops;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
 import io.nosqlbench.driver.pulsar.PulsarSpace;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.pulsar.client.api.Consumer;
@@ -20,14 +22,20 @@ import java.util.function.LongFunction;
 public class PulsarConsumerMapper extends PulsarOpMapper {
     private final LongFunction<Consumer<?>> consumerFunc;
     private final LongFunction<Boolean> asyncApiFunc;
+    private final Counter bytesCounter;
+    private final Histogram messagesizeHistogram;
 
     public PulsarConsumerMapper(CommandTemplate cmdTpl,
                                 PulsarSpace clientSpace,
                                 LongFunction<Consumer<?>> consumerFunc,
-                                LongFunction<Boolean> asyncApiFunc) {
+                                LongFunction<Boolean> asyncApiFunc,
+                                Counter bytesCounter,
+                                Histogram messagesizeHistogram) {
         super(cmdTpl, clientSpace);
         this.consumerFunc = consumerFunc;
         this.asyncApiFunc = asyncApiFunc;
+        this.bytesCounter = bytesCounter;
+        this.messagesizeHistogram = messagesizeHistogram;
     }
 
     @Override
@@ -39,7 +47,9 @@ public class PulsarConsumerMapper extends PulsarOpMapper {
             consumer,
             clientSpace.getPulsarSchema(),
             asyncApi,
-            clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds()
+            clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds(),
+            bytesCounter,
+            messagesizeHistogram
         );
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
@@ -1,5 +1,6 @@
 package io.nosqlbench.driver.pulsar.ops;
 
+import com.codahale.metrics.Counter;
 import io.nosqlbench.driver.pulsar.PulsarSpace;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.pulsar.client.api.Producer;
@@ -22,18 +23,21 @@ public class PulsarProducerMapper extends PulsarOpMapper {
     private final LongFunction<Boolean> asyncApiFunc;
     private final LongFunction<String> keyFunc;
     private final LongFunction<String> payloadFunc;
+    private final Counter bytesCounter;
 
     public PulsarProducerMapper(CommandTemplate cmdTpl,
                                 PulsarSpace clientSpace,
                                 LongFunction<Producer<?>> producerFunc,
                                 LongFunction<Boolean> asyncApiFunc,
                                 LongFunction<String> keyFunc,
-                                LongFunction<String> payloadFunc) {
+                                LongFunction<String> payloadFunc,
+                                Counter bytesCounter) {
         super(cmdTpl, clientSpace);
         this.producerFunc = producerFunc;
         this.asyncApiFunc = asyncApiFunc;
         this.keyFunc = keyFunc;
         this.payloadFunc = payloadFunc;
+        this.bytesCounter = bytesCounter;
     }
 
     @Override
@@ -48,6 +52,7 @@ public class PulsarProducerMapper extends PulsarOpMapper {
             clientSpace.getPulsarSchema(),
             asyncApi,
             msgKey,
-            msgPayload);
+            msgPayload,
+            bytesCounter);
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
@@ -1,6 +1,7 @@
 package io.nosqlbench.driver.pulsar.ops;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
 import io.nosqlbench.driver.pulsar.PulsarSpace;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.pulsar.client.api.Producer;
@@ -24,6 +25,7 @@ public class PulsarProducerMapper extends PulsarOpMapper {
     private final LongFunction<String> keyFunc;
     private final LongFunction<String> payloadFunc;
     private final Counter bytesCounter;
+    private final Histogram messagesizeHistogram;
 
     public PulsarProducerMapper(CommandTemplate cmdTpl,
                                 PulsarSpace clientSpace,
@@ -31,13 +33,15 @@ public class PulsarProducerMapper extends PulsarOpMapper {
                                 LongFunction<Boolean> asyncApiFunc,
                                 LongFunction<String> keyFunc,
                                 LongFunction<String> payloadFunc,
-                                Counter bytesCounter) {
+                                Counter bytesCounter,
+                                Histogram messagesizeHistogram) {
         super(cmdTpl, clientSpace);
         this.producerFunc = producerFunc;
         this.asyncApiFunc = asyncApiFunc;
         this.keyFunc = keyFunc;
         this.payloadFunc = payloadFunc;
         this.bytesCounter = bytesCounter;
+        this.messagesizeHistogram = messagesizeHistogram;
     }
 
     @Override
@@ -53,6 +57,7 @@ public class PulsarProducerMapper extends PulsarOpMapper {
             asyncApi,
             msgKey,
             msgPayload,
-            bytesCounter);
+            bytesCounter,
+            messagesizeHistogram);
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -249,7 +249,8 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
                 consumer_name_func.apply(l)
             );
 
-        return new PulsarConsumerMapper(cmdTpl, clientSpace, consumerFunc, async_api_func);
+        return new PulsarConsumerMapper(cmdTpl, clientSpace, consumerFunc, async_api_func,
+            pulsarActivity.getBytesCounter(), pulsarActivity.getMessagesizeHistogram());
     }
 
     private LongFunction<PulsarOp> resolveMsgRead(

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -183,7 +183,8 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             async_api_func,
             keyFunc,
             valueFunc,
-            pulsarActivity.getBytesCounter());
+            pulsarActivity.getBytesCounter(),
+            pulsarActivity.getMessagesizeHistogram());
     }
 
     private LongFunction<PulsarOp> resolveMsgConsume(

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -20,11 +20,13 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
     private final CommandTemplate cmdTpl;
     private final PulsarSpace clientSpace;
     private final LongFunction<PulsarOp> opFunc;
+    private final PulsarActivity pulsarActivity;
 
     // TODO: Add docs for the command template with respect to the OpTemplate
 
-    public ReadyPulsarOp(OpTemplate opTemplate, PulsarSpaceCache pcache) {
+    public ReadyPulsarOp(OpTemplate opTemplate, PulsarSpaceCache pcache, PulsarActivity pulsarActivity) {
         // TODO: Consider parsing map structures into equivalent binding representation
+        this.pulsarActivity = pulsarActivity;
         this.opTpl = opTemplate;
         this.cmdTpl = new CommandTemplate(opTemplate);
 
@@ -180,7 +182,8 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             producerFunc,
             async_api_func,
             keyFunc,
-            valueFunc);
+            valueFunc,
+            pulsarActivity.getBytesCounter());
     }
 
     private LongFunction<PulsarOp> resolveMsgConsume(


### PR DESCRIPTION
- Add "bytes" counter in order to track the number for bytes written to Pulsar and see the thoughtput in bytes and not in ops/sec.
- Fix dependencies