### PR TITLE
adding graphql schema first scenarios

### DIFF
--- a/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-keyvalue.yaml
@@ -1,0 +1,114 @@
+# nb -v run driver=http yaml=http-graphql-keyvalue tags=phase:schema host=my_stargate_host stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+
+# TODO 
+# - /graphqlv2 will change in future, adapt when needed
+# - do we need a truncate schema / namespace at the end
+
+description: |
+  This workload emulates a key-value data model and access patterns.
+  This should be identical to the cql variant except for:
+  - Schema creation GraphQL first, we don't use cql and thus can only create schema with limited options.
+  - There is no instrumentation with the http driver.
+  - There is no async mode with the http driver.
+  Note that stargate_port should reflect the port where GraphQL API V2 is exposed (defaults to 8080). 
+
+scenarios:
+  default:
+    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
+    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+bindings:
+  # To enable an optional weighted set of hosts in place of a load balancer
+  # Examples
+  #   single host: stargate_host=host1
+  #   multiple hosts: stargate_host=host1,host2,host3
+  #   multiple weighted hosts: stargate_host=host1:3,host2:7
+  weighted_hosts: WeightedStrings('<<stargate_host:stargate>>')
+  # http request id
+  request_id: ToHashedUUID(); ToString();
+
+  seq_key: Mod(<<keycount:1000000000>>); ToString() -> String
+  seq_value: Hash(); Mod(<<valuecount:1000000000>>); ToString() -> String
+  rw_key: <<keydist:Uniform(0,1000000000)->int>>; ToString() -> String
+  rw_value: Hash(); <<valdist:Uniform(0,1000000000)->int>>; ToString() -> String
+
+blocks:
+  - tags:
+      phase: schema
+    statements:
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  createNamespace(name: \"<<keyspace:gqlsf_keyvalue>>\", replicas: <<rf:1>>) {\n    namespace {\n      name\n    }\n  }\n}\n"
+            }
+        tags:
+          name: create-keyspace
+      - create-gql-schema : POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  deploySchema(namespace: \"<<keyspace:gqlsf_keyvalue>>\", schema: \"\"\"\n      type KeyValue @cql_input {\n        key: String! @cql_column(partitionKey: true)\n        value: String!\n      }\n      type Query {\n        getKeyValue(\n          key: String!,\n        ): KeyValue\n      }\n      type Mutation {\n    \t\tinsertKeyValue(keyValue: KeyValueInput): KeyValue\n    }\n  \"\"\") {\n    version\n  }\n}\n"
+            }
+        tags:
+          name: create-gql-schema
+
+  - name: rampup
+    tags:
+      phase: rampup
+    statements:
+      - rampup-insert: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_keyvalue>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertKeyValue(keyValue: {key: \"{seq_key}\", value: \"{seq_value}\"}) {\n    key\n    value\n  }\n}\n"
+            }
+        tags:
+          name: rampup-insert
+
+  - name: main-read
+    tags:
+      phase: main
+      type: read
+    params:
+      ratio: <<read_ratio:1>>
+    statements:
+      - main-select: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_keyvalue>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"{\n  getKeyValue(key: \"rw_key\") {\n    key\n    value\n  }\n}\n"
+            }
+        tags:
+          name: main-select
+
+  - name: main-write
+    tags:
+      phase: main
+      type: write
+    params:
+      ratio: <<write_ratio:9>>
+    statements:
+      - main-write: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_keyvalue>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertKeyValue(keyValue: {key: \"{rw_key}\", value: \"{rw_value}\"}) {\n    key\n    value\n  }\n}\n"
+            }
+        tags:
+          name: main-write

--- a/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-tabular.yaml
+++ b/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-tabular.yaml
@@ -1,0 +1,123 @@
+# nb -v run driver=http yaml=http-graphql-tabular tags=phase:schema host=my_stargate_host stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+
+# TODO 
+# - /graphqlv2 will change in future, adapt when needed
+# - do we need a truncate schema / namespace at the end
+# - rest uses limit as it queries only by a single primary key, we can not map this to GQL (also should data be clustering key)
+
+description: |
+  This workload emulates a time-series data model and access patterns.
+  This should be identical to the cql variant except for:
+  - We need to URLEncode the `data` and `data_write` bindings because newlines can't be sent in REST calls.
+  - Schema creation GraphQL first, we don't use cql and thus can only create schema with limited options.
+  - There is no instrumentation with the http driver.
+  - There is no async mode with the http driver.
+  Note that stargate_port should reflect the port where GraphQL API V2 is exposed (defaults to 8080). 
+
+scenarios:
+  default:
+    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
+    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+bindings:
+  # To enable an optional weighted set of hosts in place of a load balancer
+  # Examples
+  #   single host: stargate_host=host1
+  #   multiple hosts: stargate_host=host1,host2,host3
+  #   multiple weighted hosts: stargate_host=host1:3,host2:7
+  weighted_hosts: WeightedStrings('<<stargate_host:stargate>>')
+  # http request id
+  request_id: ToHashedUUID(); ToString();
+
+  # for ramp-up and verify
+  part_layout: Div(<<partsize:1000000>>); ToString() -> String
+  clust_layout: Mod(<<partsize:1000000>>); ToString() -> String
+  data: HashedFileExtractToString('data/lorem_ipsum_full.txt',50,150); URLEncode();
+  # for read
+  limit: Uniform(1,10) -> int
+  part_read: Uniform(0,<<partcount:100>>)->int; ToString() -> String
+  clust_read: Add(1); Uniform(0,<<partsize:1000000>>)->int; ToString() -> String
+  # for write
+  part_write: Hash(); Uniform(0,<<partcount:100>>)->int; ToString() -> String
+  clust_write: Hash(); Add(1); Uniform(0,<<partsize:1000000>>)->int; ToString() -> String
+  data_write: Hash(); HashedFileExtractToString('data/lorem_ipsum_full.txt',50,150); URLEncode();
+blocks:
+  - tags:
+      phase: schema
+    statements:
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  createNamespace(name: \"<<keyspace:gqlsf_tabular>>\", replicas: <<rf:1>>) {\n    namespace {\n      name\n    }\n  }\n}\n"
+            }
+        tags:
+          name: create-keyspace
+      - create-gql-schema : POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  deploySchema(namespace: \"<<keyspace:gqlsf_tabular>>\", schema: \"\"\"\n      type Tabular @cql_input {\n        part: String! @cql_column(partitionKey: true)\n        clust: String! @cql_column(partitionKey: true)\n        data: String! \n      }\n      type SelectTabularResult @cql_payload {\n    \t\tdata: [Tabular]\n    \t\tpagingState: String\n    }\n      type Query {\n        getTabulars(\n          part: String!,\n          clust: String!,\n          pagingState: String @cql_pagingState\n        ): SelectTabularResult @cql_select(pageSize: 10)\n      }\n      type Mutation {\n    \t\tinsertTabular(tabular: TabularInput): Tabular\n    }\n  \"\"\") {\n    version\n  }\n}\n"
+            }
+        tags:
+          name: create-gql-schema
+
+  - name: rampup
+    tags:
+      phase: rampup
+    statements:
+      - rampup-insert: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_tabular>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertTabular(tabular: {part: \"{part_layout}\", clust: \"{clust_layout}\", data: \"{data}\"}) {\n    part\n    clust\n    data\n  }\n}\n"
+            }
+        tags:
+          name: rampup-insert
+
+  - name: main-read
+    tags:
+      phase: main
+      type: read
+    params:
+      ratio: <<read_ratio:1>>
+    statements:
+      - main-select: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_tabular>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"{\n  getTabulars(part: \"{part_read}\", clust: \"{clust_read}\") {\n    data {\n      part\n      clust\n      data\n    }\n    pagingState\n  }\n}\n"
+            }
+        tags:
+          name: main-select
+
+  - name: main-write
+    tags:
+      phase: main
+      type: write
+    params:
+      ratio: <<write_ratio:9>>
+    statements:
+      - main-write: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_tabular>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertTabular(tabular: {part: \"{part_write}\", clust: \"{clust_write}\", data: \"{data_write}\"}) {\n    part\n    clust\n    data\n  }\n}\n"
+            }
+        tags:
+          name: main-write

--- a/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-timeseries.yaml
+++ b/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-timeseries.yaml
@@ -1,0 +1,121 @@
+# nb -v run driver=http yaml=http-graphql-timeseries tags=phase:schema host=my_stargate_host stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+
+# TODO 
+# - /graphqlv2 will change in future, adapt when needed
+# - do we need a truncate schema / namespace at the end
+# - support for a paging state?
+# - infinity is not handled
+# - compression and compaction not defined (limitation in the GQL schema-first API)
+
+description: |
+  This workload emulates a time-series data model and access patterns.
+  This should be identical to the cql variant except for:
+  - We can't specify the write timestamp to make the write idempotent like we can with cql.
+  - The `time` binding has to have a StringDateWrapper to get the exact format that the REST API/GraphQL needs; See https://github.com/stargate/stargate/issues/532.
+  - We need to URLEncode the `data` binding because newlines can't be sent in REST calls.
+  - Schema creation GraphQL first, we don't use cql and thus can only create schema with limited options.
+  - There is no instrumentation with the http driver.
+  - There is no async mode with the http driver.
+  Note that stargate_port should reflect the port where GraphQL API V2 is exposed (defaults to 8080). 
+
+scenarios:
+  default:
+    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
+    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+bindings:
+  # To enable an optional weighted set of hosts in place of a load balancer
+  # Examples
+  #   single host: stargate_host=host1
+  #   multiple hosts: stargate_host=host1,host2,host3
+  #   multiple weighted hosts: stargate_host=host1:3,host2:7
+  weighted_hosts: WeightedStrings('<<stargate_host:stargate>>')
+  # http request id
+  request_id: ToHashedUUID(); ToString();
+
+  machine_id: Mod(<<sources:10000>>); ToHashedUUID() -> java.util.UUID
+  sensor_name: HashedLineToString('data/variable_words.txt')
+  time: Mul(<<timespeed:100>>L); Div(<<sources:10000>>L); StringDateWrapper("yyyy-MM-dd'T'hh:mm:ss'Z");
+  sensor_value: Normal(0.0,5.0); Add(100.0) -> double
+  station_id: Div(<<sources:10000>>);Mod(<<stations:100>>); ToHashedUUID() -> java.util.UUID
+  data: HashedFileExtractToString('data/lorem_ipsum_full.txt',800,1200); URLEncode();
+blocks:
+  - tags:
+      phase: schema
+    statements:
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  createNamespace(name: \"<<keyspace:gqlsf_timeseries>>\", replicas: <<rf:1>>) {\n    namespace {\n      name\n    }\n  }\n}\n"
+            }
+        tags:
+          name: create-keyspace
+      - create-gql-schema : POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/admin
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  deploySchema(namespace: \"<<keyspace:gqlsf_timeseries>>\", schema: \"\"\"\n      type Iot @cql_input {\n        machine_id: Uuid! @cql_column(partitionKey: true)\n        sensor_name: String! @cql_column(partitionKey: true)\n        time: Timestamp! @cql_column(clusteringOrder: DESC)\n        sensor_value: Float!\n    \tstation_id: Uuid!\n        data: String!\n      }\n      type SelectIotResult @cql_payload {\n    \t\tdata: [Iot]\n    \t\tpagingState: String\n    }\n      type Query {\n        getIots(\n          machine_id: Uuid!,\n          sensor_name: String!,\n          pagingState: String @cql_pagingState\n        ): SelectIotResult @cql_select(pageSize: 10)\n      }\n      type Mutation {\n    \t\tinsertIot(iot: IotInput): Iot\n    }\n  \"\"\") {\n    version\n  }\n}\n"
+            }
+        tags:
+          name: create-gql-schema
+
+  - name: rampup
+    tags:
+      phase: rampup
+    statements:
+      - rampup-insert: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_timeseries>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertIot(iot: {machine_id: \"{machine_id}\", sensor_name: \"{sensor_name}\", time: \"{time}\", sensor_value: {sensor_value}, station_id: \"{station_id}\", data: \"{data}\"}) {\n    machine_id\n    sensor_name\n    time\n    sensor_value\n    station_id\n    data\n  }\n}\n"
+            }
+        tags:
+          name: rampup-insert
+
+  - name: main-read
+    tags:
+      phase: main
+      type: read
+    params:
+      ratio: <<read_ratio:1>>
+    statements:
+      - main-select: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_timeseries>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"{\n  getIots(machine_id: \"{machine_id}\", sensor_name: \"{sensor_name}\") {\n    data {\n      machine_id\n      sensor_name\n      time\n      sensor_value\n      station_id\n      data\n    }\n  }\n}\n"
+            }
+        tags:
+          name: main-select
+
+  - name: main-write
+    tags:
+      phase: main
+      type: write
+    params:
+      ratio: <<write_ratio:9>>
+    statements:
+      - main-write: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphqlv2/namespace/<<keyspace:gqlsf_timeseries>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+            {
+              "query":"mutation {\n  insertIot(iot: {machine_id: \"{machine_id}\", sensor_name: \"{sensor_name}\", time: \"{time}\", sensor_value: {sensor_value}, station_id: \"{station_id}\", data: \"{data}\"}) {\n    machine_id\n    sensor_name\n    time\n    sensor_value\n    station_id\n    data\n  }\n}\n"
+            }
+        tags:
+          name: main-write


### PR DESCRIPTION
Here are some guides for the reviewer, there is a list of `TODO`s in each file, but I'll try to mention the most important ones:

* I tried to replicate as must as possible the REST scenarios, however schema creation is always gql-first
* default keyspace is different in each scenario, as we have schema per keyspace in GQL
* tabular scenario
   * the rest equivalent of this uses only `part_read` when reading, but this is not possible with GraphQL API at the state we have it in the moment, as both primary keys need to be part of the querying
   * also I am not sure how `limit` would play a role due to this requirement
* timeseries
   * I can not replicate the compression and compaction as I am using graphql api to create the table (and this is not supported)
   * when I get `-Infinity` for the `sensor_name` the API request fails to parse the content, but respond to `200`.. however it would be good to skip those requests
   * paging is still not implemented in the requests, I guess it fails to the default page size of 10
   
In order to test this, you must be on the Stargate PR https://github.com/stargate/stargate/pull/634.. APIs called here are not released yet.. Example run:

```
./nb -v run driver=http yaml=./driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-timeseries.yaml tags=phase:schema host=127.0.0.4 stargate_host=127.0.0.4 auth_token=$AUTH_TOKEN 
./nb -v run driver=http yaml=./driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-timeseries.yaml tags=phase:rampup host=127.0.0.4 stargate_host=127.0.0.4 auth_token=$AUTH_TOKEN cycles=1000 threads=auto
./nb -v run driver=http yaml=./driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-timeseries.yaml tags=phase:main host=127.0.0.4 stargate_host=127.0.0.4 auth_token=$AUTH_TOKEN cycles=10000 threads=auto
```