### PR TITLE
Expose internal Pulsar Producer metrics

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpaceCache.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpaceCache.java
@@ -27,7 +27,8 @@ public class PulsarSpaceCache {
                 activity.getPulsarConf(),
                 activity.getPulsarSvcUrl(),
                 activity.getWebSvcUrl(),
-                activity.getPulsarAdmin()
+                activity.getPulsarAdmin(),
+                activity.getActivityDef()
             ));
     }
 

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/ScenarioResult.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/ScenarioResult.java
@@ -127,6 +127,14 @@ public class ScenarioResult {
                 if (count > 0) {
                     NBMetricsSummary.summarize(sb, k, v);
                 }
+            } else if (v instanceof Gauge) {
+                Object value = ((Gauge) v).getValue();
+                if (value != null && value instanceof Number) {
+                    Number n = (Number) value;
+                    if (n.doubleValue() != 0) {
+                        NBMetricsSummary.summarize(sb, k, v);
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
- expose internal metrics of the Pulsar Producer as Gauges
- dump Gauges in ScenarioResult#reportCountsTo (they are already supported in NBMetricsSummary)