### PR TITLE
Pulsar: first prototype of transaction support

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -31,6 +31,8 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
     public Timer executeTimer;
     public Counter bytesCounter;
     public Histogram messagesizeHistogram;
+    public Timer createTransactionTimer;
+    public Timer commitTransactionTimer;
 
     private PulsarSpaceCache pulsarCache;
     private PulsarAdmin pulsarAdmin;
@@ -110,6 +112,9 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
         bindTimer = ActivityMetrics.timer(activityDef, "bind");
         executeTimer = ActivityMetrics.timer(activityDef, "execute");
+        createTransactionTimer = ActivityMetrics.timer(activityDef, "createtransaction");
+        commitTransactionTimer = ActivityMetrics.timer(activityDef, "committransaction");
+
         bytesCounter = ActivityMetrics.counter(activityDef, "bytes");
         messagesizeHistogram = ActivityMetrics.histogram(activityDef, "messagesize");
 
@@ -120,7 +125,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
         pulsarSvcUrl =
             activityDef.getParams().getOptionalString("service_url").orElse("pulsar://localhost:6650");
         webSvcUrl =
-            activityDef.getParams().getOptionalString("web_url").orElse("pulsar://localhost:8080");
+            activityDef.getParams().getOptionalString("web_url").orElse("http://localhost:8080");
 
         initPulsarAdmin();
 
@@ -171,6 +176,14 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
 
     public Counter getBytesCounter() {
         return bytesCounter;
+    }
+
+    public Timer getCreateTransactionTimer() {
+        return createTransactionTimer;
+    }
+
+    public Timer getCommitTransactionTimer() {
+        return commitTransactionTimer;
     }
 
     public Histogram getMessagesizeHistogram() {

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpaceCache.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpaceCache.java
@@ -28,7 +28,8 @@ public class PulsarSpaceCache {
                 activity.getPulsarSvcUrl(),
                 activity.getWebSvcUrl(),
                 activity.getPulsarAdmin(),
-                activity.getActivityDef()
+                activity.getActivityDef(),
+                activity.getCreateTransactionTimer()
             ));
     }
 

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
@@ -2,12 +2,15 @@ package io.nosqlbench.driver.pulsar.ops;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Timer;
 import io.nosqlbench.driver.pulsar.PulsarSpace;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.transaction.Transaction;
 
 import java.util.function.LongFunction;
+import java.util.function.Supplier;
 
 /**
  * This maps a set of specifier functions to a pulsar operation. The pulsar operation contains
@@ -23,23 +26,34 @@ public class PulsarConsumerMapper extends PulsarOpMapper {
     private final LongFunction<Consumer<?>> consumerFunc;
     private final Counter bytesCounter;
     private final Histogram messagesizeHistogram;
+    private final LongFunction<Boolean> useTransactionFunc;
+    private final LongFunction<Supplier<Transaction>> transactionSupplierFunc;
+    private final Timer transactionCommitTimer;
 
     public PulsarConsumerMapper(CommandTemplate cmdTpl,
                                 PulsarSpace clientSpace,
                                 LongFunction<Boolean> asyncApiFunc,
                                 LongFunction<Consumer<?>> consumerFunc,
                                 Counter bytesCounter,
-                                Histogram messagesizeHistogram) {
+                                Histogram messagesizeHistogram,
+                                Timer transactionCommitTimer,
+                                LongFunction<Boolean> useTransactionFunc,
+                                LongFunction<Supplier<Transaction>> transactionSupplierFunc) {
         super(cmdTpl, clientSpace, asyncApiFunc);
         this.consumerFunc = consumerFunc;
         this.bytesCounter = bytesCounter;
         this.messagesizeHistogram = messagesizeHistogram;
+        this.transactionCommitTimer = transactionCommitTimer;
+        this.useTransactionFunc = useTransactionFunc;
+        this.transactionSupplierFunc = transactionSupplierFunc;
     }
 
     @Override
     public PulsarOp apply(long value) {
         Consumer<?> consumer = consumerFunc.apply(value);
         boolean asyncApi = asyncApiFunc.apply(value);
+        boolean useTransaction = useTransactionFunc.apply(value);
+        Supplier<Transaction> transactionSupplier = transactionSupplierFunc.apply(value);
 
         return new PulsarConsumerOp(
             consumer,
@@ -47,7 +61,10 @@ public class PulsarConsumerMapper extends PulsarOpMapper {
             asyncApi,
             clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds(),
             bytesCounter,
-            messagesizeHistogram
+            messagesizeHistogram,
+            useTransaction,
+            transactionSupplier,
+            transactionCommitTimer
         );
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerOp.java
@@ -2,6 +2,7 @@ package io.nosqlbench.driver.pulsar.ops;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Timer;
 import io.nosqlbench.driver.pulsar.PulsarActivity;
 import io.nosqlbench.driver.pulsar.util.AvroUtil;
 import io.nosqlbench.driver.pulsar.util.PulsarActivityUtil;
@@ -9,11 +10,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 public class PulsarProducerOp implements PulsarOp {
 
@@ -27,10 +31,14 @@ public class PulsarProducerOp implements PulsarOp {
     private final Counter bytesCounter;
     private final Histogram messagesizeHistogram;
     private final PulsarActivity pulsarActivity;
+    private final boolean useTransaction;
+    private final Supplier<Transaction> transactionSupplier;
 
     public PulsarProducerOp(Producer<?> producer,
                             Schema<?> schema,
                             boolean asyncPulsarOp,
+                            boolean useTransaction,
+                            Supplier<Transaction> transactionSupplier,
                             String key,
                             String payload,
                             PulsarActivity pulsarActivity) {
@@ -42,6 +50,8 @@ public class PulsarProducerOp implements PulsarOp {
         this.pulsarActivity = pulsarActivity;
         this.bytesCounter = pulsarActivity.getBytesCounter();
         this.messagesizeHistogram = pulsarActivity.getMessagesizeHistogram();
+        this.useTransaction = useTransaction;
+        this.transactionSupplier = transactionSupplier;
     }
 
     @Override
@@ -49,8 +59,16 @@ public class PulsarProducerOp implements PulsarOp {
         if ((msgPayload == null) || msgPayload.isEmpty()) {
             throw new RuntimeException("Message payload (\"msg-value\") can't be empty!");
         }
-
-        TypedMessageBuilder typedMessageBuilder = producer.newMessage(pulsarSchema);
+        TypedMessageBuilder typedMessageBuilder;
+        final Transaction transaction;
+        if (useTransaction) {
+            // if you are in a transaction you cannot set the schema per-message
+            transaction = transactionSupplier.get();
+            typedMessageBuilder = producer.newMessage(transaction);
+        } else {
+            transaction = null;
+            typedMessageBuilder = producer.newMessage(pulsarSchema);
+        }
         if ((msgKey != null) && (!msgKey.isEmpty())) {
             typedMessageBuilder = typedMessageBuilder.key(msgKey);
         }
@@ -79,7 +97,12 @@ public class PulsarProducerOp implements PulsarOp {
             try {
                 logger.trace("sending message");
                 typedMessageBuilder.send();
-            } catch (PulsarClientException pce) {
+                if (useTransaction) {
+                    try (Timer.Context ctx = pulsarActivity.getCommitTransactionTimer().time();) {
+                        transaction.commit().get();
+                    }
+                }
+            } catch (PulsarClientException | ExecutionException | InterruptedException pce) {
                 logger.trace("failed sending message");
                 throw new RuntimeException(pce);
             }
@@ -87,8 +110,23 @@ public class PulsarProducerOp implements PulsarOp {
         } else {
             try {
                 // we rely on blockIfQueueIsFull in order to throttle the request in this case
-                CompletableFuture<MessageId> future = typedMessageBuilder.sendAsync();
-                future.whenComplete((messageId, error) -> timeTracker.run()).exceptionally(ex -> {
+                CompletableFuture<?> future = typedMessageBuilder.sendAsync();
+                if (useTransaction) {
+                    // add commit step
+                    future = future.thenCompose(msg -> {
+                        Timer.Context ctx = pulsarActivity.getCommitTransactionTimer().time();;
+                        return transaction
+                            .commit()
+                            .whenComplete((m,e) -> {
+                                ctx.close();
+                            })
+                            .thenApply(v-> msg);
+                        }
+                    );
+                }
+                future.whenComplete((messageId, error) -> {
+                    timeTracker.run();
+                }).exceptionally(ex -> {
                     logger.error("Producing message failed: key - " + msgKey + "; payload - " + msgPayload);
                     pulsarActivity.asyncOperationFailed(ex);
                     return null;

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -49,6 +49,7 @@ public class PulsarActivityUtil {
     public enum DOC_LEVEL_PARAMS {
         TOPIC_URI("topic_uri"),
         ASYNC_API("async_api"),
+        USE_TRANSACTION("use_transaction"),
         ADMIN_DELOP("admin_delop");
 
         public final String label;


### PR DESCRIPTION
Introduce "use_transaction" parameter for Produce Op and ConsumeOp.
Add metrics about starting the transaction and commit the transaction.

Support for the Producer is 100% working both in sync and in async mode.
Support for Consumer is only a prototype as we need to separate the time spent for "receive" and for "commit".