### PR TITLE
Fix graphql timeseries read query

### DIFF
--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-timeseries.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-timeseries.yaml
@@ -92,7 +92,7 @@ blocks:
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
         Content-Type: "application/json"
         body: |
-          {"query":"query readings {<<table:iot>>(value: {machine_id: \"{machine_id}\",sensor_name: \"{machine_id}\"}, options: { pageSize: <<limit:10>> }) {values {machine_id, sensor_name, time, data, sensor_value, station_id}}}"}
+          {"query":"query readings {<<table:iot>>(value: {machine_id: \"{machine_id}\",sensor_name: \"{sensor_name}\"}, options: { pageSize: <<limit:10>> }) {values {machine_id, sensor_name, time, data, sensor_value, station_id}}}"}
         tags:
           name: main-select
   - name: main-write


### PR DESCRIPTION
Fixing bad copy paste in the graphql query of the read request in the timeseries workload.