### PR TITLE
Use http requests when creating schema for rest and graphql

### DIFF
--- a/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
@@ -29,23 +29,76 @@ blocks:
   - name: schema
     tags:
       phase: schema
-    params:
-      prepared: false
     statements:
-      - create-keyspace: |
-          create keyspace if not exists <<keyspace:baselines>>
-          WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<<rf:1>>'}
-          AND durable_writes = true;
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<keyspace:baselines>>",
+              "replicas": <<rf:1>>
+          }
         tags:
           name: create-keyspace
-      - create-table: |
-          create table if not exists <<keyspace:baselines>>.<<table:keyvalue>> (
-          key text,
-           value text,
-           PRIMARY KEY (key)
-          );
+      - create-table: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:keyvalue>>",
+              "columnDefinitions": [
+                  {
+                      "name": "key",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "value",
+                      "typeDefinition": "text"
+                  }
+              ],
+              "primaryKey": {
+                  "partitionKey": [
+                      "key"
+                  ]
+              },
+              "ifNotExists": true
+          }
         tags:
           name: create-table
+  - tags:
+      phase: schema-astra
+    statements:
+      - create-table-astra: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:keyvalue>>",
+              "columnDefinitions": [
+                  {
+                      "name": "key",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "value",
+                      "typeDefinition": "text"
+                  }
+              ],
+              "primaryKey": {
+                  "partitionKey": [
+                      "key"
+                  ]
+              },
+              "ifNotExists": true
+          }
+        tags:
+          name: create-table-astra
   - name: rampup
     tags:
       phase: rampup

--- a/driver-http/src/main/resources/activities/baselines/http-rest-tabular.yaml
+++ b/driver-http/src/main/resources/activities/baselines/http-rest-tabular.yaml
@@ -37,24 +37,90 @@ blocks:
   - name: schema
     tags:
       phase: schema
-    params:
-      prepared: false
     statements:
-      - create-keyspace: |
-          create keyspace if not exists <<keyspace:baselines>>
-          WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<<rf:1>>'}
-          AND durable_writes = true;
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<keyspace:baselines>>",
+              "replicas": <<rf:1>>
+          }
         tags:
           name: create-keyspace
-      - create-table: |
-          create table if not exists <<keyspace:baselines>>.<<table:tabular>> (
-           part text,
-           clust text,
-           data text,
-           PRIMARY KEY (part,clust)
-          );
+      - create-table: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:tabular>>",
+              "columnDefinitions": [
+                  {
+                      "name": "part",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "clust",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "data",
+                      "typeDefinition": "text"
+                  }
+              ],
+              "primaryKey": {
+                  "partitionKey": [
+                      "part"
+                  ],
+                  "clusteringKey": [
+                      "clust"
+                  ]
+              },
+              "ifNotExists": true
+          }
         tags:
           name: create-table
+  - tags:
+      phase: schema-astra
+    statements:
+      - create-table-astra: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:tabular>>",
+              "columnDefinitions": [
+                  {
+                      "name": "part",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "clust",
+                      "typeDefinition": "text"
+                  },
+                  {
+                      "name": "data",
+                      "typeDefinition": "text"
+                  }
+              ],
+              "primaryKey": {
+                  "partitionKey": [
+                      "part"
+                  ],
+                  "clusteringKey": [
+                      "clust"
+                  ]
+              },
+              "ifNotExists": true
+          }
+        tags:
+          name: create-table-astra
   - name: rampup
     tags:
       phase: rampup

--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
@@ -30,23 +30,37 @@ blocks:
   - name: schema
     tags:
       phase: schema
-    params:
-      prepared: false
     statements:
-      - create-keyspace: |
-          create keyspace if not exists <<keyspace:gqlcf_keyvalue>>
-          WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<<rf:1>>'}
-          AND durable_writes = true;
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createKeyspace(name:\"<<keyspace:gqlcf_tabular>>\", replicas: <<rf:1>>, ifNotExists: true)\n}"}
         tags:
           name: create-keyspace
-      - create-table: |
-          create table if not exists <<keyspace:gqlcf_keyvalue>>.<<table:keyvalue>> (
-          key text,
-           value text,
-           PRIMARY KEY (key)
-          );
+      - create-table: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createTable(\n    keyspaceName: \"<<keyspace:gqlcf_keyvalue>>\"\n    tableName: \"<<table:keyvalue>>\"\n    partitionKeys: [{ name: \"key\", type: { basic: TEXT } }]\n    values: [{ name: \"value\", type: { basic: TEXT } }]\n    ifNotExists: true\n  )\n}"}
         tags:
           name: create-table
+  - tags:
+      phase: schema-astra
+    statements:
+      - create-table-astra: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createTable(\n    keyspaceName: \"<<keyspace:gqlcf_keyvalue>>\"\n    tableName: \"<<table:keyvalue>>\"\n    partitionKeys: [{ name: \"key\", type: { basic: TEXT } }]\n    values: [{ name: \"value\", type: { basic: TEXT } }]\n    ifNotExists: true\n  )\n}"}
+        tags:
+          name: create-table-astra
   - name: rampup
     tags:
       phase: rampup

--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-tabular.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-tabular.yaml
@@ -38,24 +38,37 @@ blocks:
   - name: schema
     tags:
       phase: schema
-    params:
-      prepared: false
     statements:
-      - create-keyspace: |
-          create keyspace if not exists <<keyspace:gqlcf_tabular>>
-          WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<<rf:1>>'}
-          AND durable_writes = true;
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createKeyspace(name:\"<<keyspace:gqlcf_tabular>>\", replicas: <<rf:1>>, ifNotExists: true)\n}"}
         tags:
           name: create-keyspace
-      - create-table: |
-          create table if not exists <<keyspace:gqlcf_tabular>>.<<table:tabular>> (
-           part text,
-           clust text,
-           data text,
-           PRIMARY KEY (part,clust)
-          );
+      - create-table: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createTable(\n    keyspaceName: \"<<keyspace:gqlcf_tabular>>\"\n    tableName: \"<<table:tabular>>\"\n    partitionKeys: [{ name: \"part\", type: { basic: TEXT } }]\n    clusteringKeys: [{ name: \"clust\", type: { basic: TEXT } }]\n    values: [{ name: \"data\", type: { basic: TEXT } }]\n    ifNotExists: true\n  )\n}\n"}
         tags:
           name: create-table
+  - tags:
+      phase: schema-astra
+    statements:
+      - create-table-astra: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql-schema
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {"query":"mutation {\n  createTable(\n    keyspaceName: \"<<keyspace:gqlcf_tabular>>\"\n    tableName: \"<<table:tabular>>\"\n    partitionKeys: [{ name: \"part\", type: { basic: TEXT } }]\n    clusteringKeys: [{ name: \"clust\", type: { basic: TEXT } }]\n    values: [{ name: \"data\", type: { basic: TEXT } }]\n    ifNotExists: true\n  )\n}\n"}
+        tags:
+          name: create-table-astra
   - name: rampup
     tags:
       phase: rampup


### PR DESCRIPTION
Not updating the timeseries workloads since they require special table options not currently exposed by stargate.

cc: @jeromatron @ivansenic 