### PR TITLE
Handle listing docker images without repo tags

### DIFF
--- a/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerHelper.java
+++ b/engine-docker/src/main/java/io/nosqlbench/engine/docker/DockerHelper.java
@@ -228,6 +228,10 @@ public class DockerHelper {
         List<String> validRepoTags = tags.stream().map(s -> label + ":" + s).collect(Collectors.toList());
         for (Image image : images) {
             String[] foundRepoTags = image.getRepoTags();
+            if (foundRepoTags == null) {
+                continue;
+            }
+
             for (String foundRepoTag : foundRepoTags) {
                 for (String validRepoTag : validRepoTags) {
                     if (foundRepoTag.equals(validRepoTag)) {


### PR DESCRIPTION
This is primarily an issue with my local but I'm sure someone else will bump into it. Basically what's going on is I have some locally built docker images that do not have repo tags like below

```
╰─$ docker images | grep none
<none>                                                   <none>                                     776d303cfa45   7 weeks ago     1.31GB
kindest/node                                             <none>                                     094599011731   3 months ago    1.17GB
```

This means that when the list of images is being filtered you get the following console output.

```java
    593 INFO  [main] NBCLI        Docker metrics is enabled. Docker must be installed for this to work
    801 INFO  [main] DockerMetricsManager preparing to start graphite exporter container...
    908 INFO  [main] DockerHelper Starting docker with img=prom/graphite-exporter, tag=latest, name=graphite-exporter, ports=[9108, 9109], volumes=[/Users/doug.wettlaufer/.nosqlbench/graphite-exporter/graphite_mapping.conf:/tmp/graphite_mapping.conf], env=[], cmds=[--graphite.mapping-config=/tmp/graphite_mapping.conf], reload=null
   1067 ERROR [main] ERRORHANDLER Cannot read the array length because "<local8>" is null
   1067 ERROR [main] ERRORHANDLER for the full stack trace, run with --show-stacktraces
Scenario stopped due to error. See logs for details.
```