### PR TITLE
Refactor JDBCActivity to use NBErrorHandler

### DIFF
--- a/driver-cockroachdb/src/main/resources/cockroachdb.md
+++ b/driver-cockroachdb/src/main/resources/cockroachdb.md
@@ -10,11 +10,17 @@ the
 [DataSource Configuration Properties](https://jdbc.postgresql.org/documentation/81/ds-ds.html)
 section for detailed parameter documentation.
 
-* **serverName** (required) - database hostname
-* **portNumber** (optional) - database listen port; defaults to 26257.
-* **user** (optional) - database account username; defaults to empty.
-* **password** (optional) - database account password; defaults to empty.
-* **connectionpool** (optional) - connection pool implementation; defaults
-  to no connection pool. Allowed values:
+* **serverName** (required) - database hostname.
+* **databaseName** (optional) - database namespace to use; Default *null*.
+* **portNumber** (optional) - database listen port; Default *26257*.
+* **user** (optional) - database account username; Default *null*.
+* **password** (optional) - database account password; Default *null*.
+* **connectionpool** (optional) - connection pool implementation; Default
+  no connection pool, in other words create a connection per statement execution.
+  Allowed values:
     * *hikari* -
       use [HikariCP](https://github.com/brettwooldridge/HikariCP)
+* **maxtries** (optional) - number of times to retry retry-able errors; Default *3*.
+* **errors** (optional) - expression which specifies how to handle SQL state error codes.
+  Expression syntax and behavior is explained in the `error-handlers` topic. Default
+  *stop*, in other words exit on any error.

--- a/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
+++ b/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
@@ -1,0 +1,33 @@
+package io.nosqlbench.activitytype.cockroachdb;
+
+import io.nosqlbench.engine.api.activityimpl.ActivityDef;
+import io.nosqlbench.engine.api.activityimpl.ParameterMap;
+import org.junit.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class CockroachActivityTest {
+    @Test
+    public void testErrorNameMapper() {
+        ActivityDef activityDef = new ActivityDef(ParameterMap.parseParams("").orElseThrow());
+        CockroachActivity activity = new CockroachActivity(activityDef);
+
+        // When the Throwable is a SQLException, the error name should be getSQLState()
+        Throwable sqlException = new SQLException("my test exception", "my-test-sql-state");
+        assertEquals("my-test-sql-state", activity.errorNameMapper(sqlException));
+
+        // See PSQLState to string code mapping at the Github source code website
+        // https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
+        Throwable psqlException = new PSQLException("retry transaction", PSQLState.CONNECTION_FAILURE);
+        assertEquals("08006", activity.errorNameMapper(psqlException));
+
+        // When Throwable is not a SQLException, the error name should be the class name
+        Throwable runtimeException = new SocketTimeoutException("my test runtime exception");
+        assertEquals("SocketTimeoutException", activity.errorNameMapper(runtimeException));
+    }
+}


### PR DESCRIPTION
Fixes issue #304 

**Breaking change**: cockroachdb driver will now fail-fast on any error by default, whereas before it would retry most errors 3 times, continue to the next action, and fail silently

Other changes:
- cockroachdb driver now takes _error=<error-handler-spec>_ parameter which specifies the NBErrorHandler behavior. The default NBErrorHandler is used for now (default _stop_), with intention to provide better defaults for CockroachDB (see CockroachActivity TODO note). 
- custom getErrorNameMapper() returns the SQL State Error code string if exception is a SQLException, else the plain class name.
- custom error metric counters removed, because they are handled internally by NBErrorHandler.