### PR TITLE
Try to use Pulsar 2.8.0-SNAPSHOT, requiring JDK11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:15-alpine
-RUN apk --no-cache add curl
+FROM openjdk:11
+RUN apt-get update && apt-get install -y curl ash
 
 COPY nb/target/nb.jar nb.jar
 ENTRYPOINT ["java","-jar", "nb.jar"]

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <pulsar.version>2.7.1</pulsar.version>
+        <pulsar.version>2.8.0-SNAPSHOT</pulsar.version>
     </properties>
 
     <dependencies>

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -97,9 +97,6 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
             adminBuilder.allowTlsInsecureConnection(tlsAllowInsecureConnection);
             pulsarAdmin = adminBuilder.build();
 
-            ClientConfigurationData configurationData = pulsarAdmin.getClientConfigData();
-            logger.debug(configurationData.toString());
-
         } catch (PulsarClientException e) {
             logger.error("Fail to create PulsarAdmin from global configuration!");
             throw new RuntimeException("Fail to create PulsarAdmin from global configuration!");

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
@@ -221,7 +221,7 @@ public class PulsarSpace {
                     .newTransaction()
                     .build()
                     .get();
-            } catch (ExecutionException | InterruptedException err) {
+            } catch (ExecutionException | InterruptedException | PulsarClientException err) {
                 if (logger.isWarnEnabled()) {
                     logger.warn("Error while starting a new transaction", err);
                 }


### PR DESCRIPTION
I am trying to use Pulsar 2.8.0, but when I try to use it with the docker image it breaks with a JVM Core Dump

So I am exploring to use JDK11 with NB

in this case Fallout dies with:
```
2021-06-01 16:07:27,477 [FJP:927]             ERROR server-1             - [CMD-FAIL] Command completed with non-zero exit code 2: kubectl --namespace=mypulsar exec --container=nosqlbench nosqlbench-deployment-687dd4c7f6-28wg2 -- ash -o pipefail -c ' java -jar nb.jar run alias=produce_messages type=pulsar config=/fallout-library/config-txt/config.txt yaml=/fallout-library/pulsar-yaml/pulsar.yaml tags=phase:producer service_url=pulsar://pulsar-proxy:6650 web_url=http://pulsar-proxy:8080 async_api=true optype=msg-send threads=10 cycles=0..100000 host=dummy-cassandra --show-stacktraces -v --log-histograms /nosqlbench/produce_messages.hdr::5s --log-histostats /nosqlbench/produce_messages.csv::5s 2>&1 | tee /nosqlbench/produce_messages.log'
STDERR (last 2 lines):
ash: 0: Illegal option -o pipefail
command terminated with exit code 2

2021-06-01 16:07:31,377 [FJP:927]             ERROR server-1             - [CMD-FAIL] Command completed with non-zero exit code 2: kubectl --namespace=mypulsar exec --container=nosqlbench nosqlbench-deployment-687dd4c7f6-28wg2 -- ash -o pipefail -c ' java -jar nb.jar run alias=consume_messages type=pulsar config=/fallout-library/config-txt/config.txt yaml=/fallout-library/pulsar-yaml/pulsar.yaml tags=phase:consumer service_url=pulsar://pulsar-proxy:6650 web_url=http://pulsar-proxy:8080 optype=msg-consume cycles=0..100000 host=dummy-cassandra --show-stacktraces -v --log-histograms /nosqlbench/consume_messages.hdr::5s --log-histostats /nosqlbench/consume_messages.csv::5s 2>&1 | tee /nosqlbench/consume_messages.log'
STDERR (last 2 lines):
ash: 0: Illegal option -o pipefail
command terminated with exit code 2

2021-06-01 16:07:31,381 [clojure:254]         ERROR nofail               - History in jepsen-history.json contained 2 failures:
First failure: Operation{time=78763443371, process=produce_messages, module=nosqlbench, type=fail, mediaType="text/plain; charset=utf-8", value="nosqlbench failed"}
Last failure: Operation{time=82663184567, process=consume_messages, module=nosqlbench, type=fail, mediaType="text/plain; charset=utf-8", value="nosqlbench failed"}
2021-06-01 16:07:31,387 [clojure:254]         ERROR nofail               - Checker 'nofail' has failed the check.
2021-06-01 16:10:06,075 [ThreadedExecutor:34] ERROR generate_chart       - No HDR files found.
```