### PR TITLE
avoid decoding msgBody twice in JmsMsgSendOp

### DIFF
--- a/driver-jms/src/main/java/io/nosqlbench/driver/jms/ops/JmsMsgSendOp.java
+++ b/driver-jms/src/main/java/io/nosqlbench/driver/jms/ops/JmsMsgSendOp.java
@@ -108,11 +108,10 @@ public class JmsMsgSendOp extends JmsTimeTrackOp {
 
     @Override
     public void run() {
-        int messageSize;
         try {
             byte[] msgBytes = msgBody.getBytes(StandardCharsets.UTF_8);
-            messageSize = msgBytes.length;
-            jmsProducer.send(jmsDestination, msgBody.getBytes(StandardCharsets.UTF_8));
+            int messageSize = msgBytes.length;
+            jmsProducer.send(jmsDestination, msgBytes);
 
             messagesizeHistogram.update(messageSize);
             bytesCounter.inc(messageSize);


### PR DESCRIPTION
small improvement i noticed while reading through https://github.com/nosqlbench/nosqlbench/pull/311

not sure if this has any positive impact on the driver's performance.