### PR TITLE
simplify cache key creation in pulsar + jms driver

### DIFF
--- a/driver-jms/src/main/java/io/nosqlbench/driver/jms/JmsActivity.java
+++ b/driver-jms/src/main/java/io/nosqlbench/driver/jms/JmsActivity.java
@@ -116,13 +116,16 @@ public class JmsActivity extends SimpleActivity {
         );
     }
 
+    private static String buildCacheKey(String... keyParts) {
+        return String.join("::", keyParts);
+    }
+
     /**
      * If the JMS destination that corresponds to a topic exists, reuse it; Otherwise, create it
      */
     public Destination getOrCreateJmsDestination(String jmsDestinationType, String destName) {
-        String encodedTopicStr =
-            JmsUtil.encode(jmsDestinationType, destName);
-        Destination destination = jmsDestinations.get(encodedTopicStr);
+        String destinationCacheKey = buildCacheKey(jmsDestinationType, destName);
+        Destination destination = jmsDestinations.get(destinationCacheKey);
 
         if ( destination == null ) {
             // TODO: should we match Persistent/Non-peristent JMS Delivery mode with
@@ -133,7 +136,7 @@ public class JmsActivity extends SimpleActivity {
                 destination = jmsContext.createTopic(destName);
             }
 
-            jmsDestinations.put(encodedTopicStr, destination);
+            jmsDestinations.put(destinationCacheKey, destination);
         }
 
         return destination;

--- a/driver-jms/src/main/java/io/nosqlbench/driver/jms/util/JmsUtil.java
+++ b/driver-jms/src/main/java/io/nosqlbench/driver/jms/util/JmsUtil.java
@@ -1,11 +1,9 @@
 package io.nosqlbench.driver.jms.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
-import java.util.Base64;
 
 public class JmsUtil {
 
@@ -101,19 +99,6 @@ public class JmsUtil {
     }
     public static boolean isValidJmsDestinationType(String type) {
         return Arrays.stream(JMS_DESTINATION_TYPES.values()).anyMatch(t -> t.label.equals(type));
-    }
-
-    public static String encode(String... strings) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (String str : strings) {
-            if (!StringUtils.isBlank(str))
-                stringBuilder.append(str).append("::");
-        }
-
-        String concatenatedStr =
-            StringUtils.substringBeforeLast(stringBuilder.toString(), "::");
-
-        return Base64.getEncoder().encodeToString(concatenatedStr.getBytes());
     }
 }
 

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -15,7 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
@@ -402,19 +401,6 @@ public class PulsarActivityUtil {
         }
 
         return schema;
-    }
-
-    public static String encode(String... strings) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (String str : strings) {
-            if (!StringUtils.isBlank(str))
-                stringBuilder.append(str).append("::");
-        }
-
-        String concatenatedStr =
-            StringUtils.substringBeforeLast(stringBuilder.toString(), "::");
-
-        return Base64.getEncoder().encodeToString(concatenatedStr.getBytes());
     }
 }
 


### PR DESCRIPTION
i was looking into whether the use of the default system encoding in `.getBytes()` in the `static String encode(String... strings)` helper methods was problematic or not.
turns out it isnt, because the result is only used as a caching key in a `ConcurrentHashMap`, however this also means that the base64 encoding is completely unnecessary imo.

note that previously only parts where `StringUtils.isBlank(part)` returns false were joined, while now the parts are joined always as `"null"` or `""`.
this change in behavior imo is actually preferrable since `encode("foo", null)` and `encode(null, "foo")` used to return the same result, whereas now they would return `foo::null` and `null::foo`, which seems more deterministic (no unwanted cache collisions?)