### PR TITLE
Remove junit4 dependency

### DIFF
--- a/docsys/src/test/java/io/nosqlbench/docsys/core/DocsysMarkdownLoaderEndpointTest.java
+++ b/docsys/src/test/java/io/nosqlbench/docsys/core/DocsysMarkdownLoaderEndpointTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.docsys.core;
 
 import io.nosqlbench.docsys.endpoints.DocsysMarkdownEndpoint;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DocsysMarkdownLoaderEndpointTest {
 

--- a/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
+++ b/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
@@ -2,14 +2,14 @@ package io.nosqlbench.activitytype.cockroachdb;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.activityimpl.ParameterMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 import java.net.SocketTimeoutException;
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CockroachActivityTest {
     @Test

--- a/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/CqlActionTest.java
+++ b/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/CqlActionTest.java
@@ -3,13 +3,13 @@ package com.datastax.ebdrivers.cql;
 import io.nosqlbench.activitytype.cql.core.CqlAction;
 import io.nosqlbench.activitytype.cql.core.CqlActivity;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CqlActionTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testCqlAction() {
         ActivityDef ad = ActivityDef.parseActivityDef("driver=ebdrivers;alias=foo;yaml=write-telemetry.yaml;");
         CqlActivity cac = new CqlActivity(ad);

--- a/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLCQLStatementDefParserTest.java
+++ b/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLCQLStatementDefParserTest.java
@@ -1,7 +1,7 @@
 package com.datastax.ebdrivers.cql.statements;
 
 import io.nosqlbench.activitytype.cql.statements.core.CQLStatementDefParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;

--- a/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLOptionsTest.java
+++ b/driver-cql-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLOptionsTest.java
@@ -8,7 +8,7 @@ import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
 import io.nosqlbench.activitytype.cql.core.CQLOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/core/CqlActivityTest.java
+++ b/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/core/CqlActivityTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.activitytype.cql.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/double_to_cqlduration/CqlDurationTests.java
+++ b/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/double_to_cqlduration/CqlDurationTests.java
@@ -3,7 +3,7 @@ package io.nosqlbench.activitytype.cql.datamappers.functions.double_to_cqldurati
 import com.datastax.driver.core.Duration;
 import io.nosqlbench.activitytype.cql.datamappers.functions.long_to_cqlduration.CqlDurationFunctions;
 import io.nosqlbench.activitytype.cql.datamappers.functions.long_to_cqlduration.ToCqlDurationNanos;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.LongToIntFunction;
 import java.util.function.LongUnaryOperator;

--- a/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/long_localdate/EpochMillisToJavaLocalDateTest.java
+++ b/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/long_localdate/EpochMillisToJavaLocalDateTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.activitytype.cql.datamappers.functions.long_localdate;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/to_daterange/DateRangeFuncTest.java
+++ b/driver-cql-shaded/src/test/java/io/nosqlbench/activitytype/cql/datamappers/functions/to_daterange/DateRangeFuncTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.activitytype.cql.datamappers.functions.to_daterange;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;

--- a/driver-cql-shaded/src/test/java/io/nosqlbench/generators/cql/lang/ParserForCqlTest.java
+++ b/driver-cql-shaded/src/test/java/io/nosqlbench/generators/cql/lang/ParserForCqlTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.generators.cql.lang;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;

--- a/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/CqlActionTest.java
+++ b/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/CqlActionTest.java
@@ -3,13 +3,13 @@ package com.datastax.ebdrivers.cql;
 import io.nosqlbench.activitytype.cql.core.CqlAction;
 import io.nosqlbench.activitytype.cql.core.CqlActivity;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CqlActionTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testCqlAction() {
         ActivityDef ad = ActivityDef.parseActivityDef("driver=ebdrivers;alias=foo;yaml=write-telemetry.yaml;");
         CqlActivity cac = new CqlActivity(ad);

--- a/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLCQLStatementDefParserTest.java
+++ b/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLCQLStatementDefParserTest.java
@@ -1,7 +1,7 @@
 package com.datastax.ebdrivers.cql.statements;
 
 import io.nosqlbench.activitytype.cql.statements.core.CQLStatementDefParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;

--- a/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLOptionsTest.java
+++ b/driver-cqld3-shaded/src/test/java/com/datastax/ebdrivers/cql/statements/CQLOptionsTest.java
@@ -8,7 +8,7 @@ import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
 import io.nosqlbench.activitytype.cql.core.CQLOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/driver-cqld3-shaded/src/test/java/io/nosqlbench/activitytype/cql/core/CqlActivityTest.java
+++ b/driver-cqld3-shaded/src/test/java/io/nosqlbench/activitytype/cql/core/CqlActivityTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.activitytype.cql.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/driver-cqld3-shaded/src/test/java/io/nosqlbench/generators/cql/lang/ParserForCqlTest.java
+++ b/driver-cqld3-shaded/src/test/java/io/nosqlbench/generators/cql/lang/ParserForCqlTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.generators.cql.lang;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;

--- a/driver-diag/src/test/java/io/nosqlbench/activitytype/diag/DiagActivityTypeTest.java
+++ b/driver-diag/src/test/java/io/nosqlbench/activitytype/diag/DiagActivityTypeTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.engine.api.activityapi.core.Action;
 import io.nosqlbench.engine.api.activityapi.core.ActionDispenser;
 import io.nosqlbench.engine.api.activityapi.core.SyncAction;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /*
 *   Copyright 2016 jshook

--- a/driver-diag/src/test/java/io/nosqlbench/activitytype/diag/SequenceBlockerTest.java
+++ b/driver-diag/src/test/java/io/nosqlbench/activitytype/diag/SequenceBlockerTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.activitytype.diag;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.PrintStream;
 

--- a/driver-http/src/test/java/io/nosqlbench/activitytype/cmds/HttpFormatParserTest.java
+++ b/driver-http/src/test/java/io/nosqlbench/activitytype/cmds/HttpFormatParserTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.activitytype.cmds;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 

--- a/driver-http/src/test/java/io/nosqlbench/activitytype/cmds/ReadyHttpOpTest.java
+++ b/driver-http/src/test/java/io/nosqlbench/activitytype/cmds/ReadyHttpOpTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.activitytype.cmds;
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import io.nosqlbench.engine.api.activityconfig.yaml.OpTemplate;
 import io.nosqlbench.engine.api.activityconfig.yaml.StmtsDocList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpRequest;
 import java.util.Map;

--- a/driver-http/src/test/java/io/nosqlbench/activitytype/http/HttpActivityTypeTest.java
+++ b/driver-http/src/test/java/io/nosqlbench/activitytype/http/HttpActivityTypeTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.activitytype.http;
 import io.nosqlbench.engine.api.activityapi.core.Action;
 import io.nosqlbench.engine.api.activityapi.core.ActionDispenser;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HttpActivityTypeTest {
     @Test

--- a/driver-jmx/src/test/java/io/nosqlbench/driver/jmx/ValueConverterTest.java
+++ b/driver-jmx/src/test/java/io/nosqlbench/driver/jmx/ValueConverterTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.driver.jmx;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/driver-mongodb/src/test/java/io/nosqlbench/driver/mongodb/MongoActivityTest.java
+++ b/driver-mongodb/src/test/java/io/nosqlbench/driver/mongodb/MongoActivityTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.driver.mongodb;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.nosqlbench.engine.api.activityapi.planning.OpSequence;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
@@ -12,7 +12,7 @@ public class MongoActivityTest {
 
     private ActivityDef activityDef;
 
-    @Before
+    @BeforeEach
     public void setup() {
         String[] params = {
                 "yaml=activities/mongodb-basic.yaml",

--- a/driver-mongodb/src/test/java/io/nosqlbench/driver/mongodb/ReadyMongoStatementTest.java
+++ b/driver-mongodb/src/test/java/io/nosqlbench/driver/mongodb/ReadyMongoStatementTest.java
@@ -10,8 +10,8 @@ import io.nosqlbench.virtdata.core.templates.BindPoint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bson.conversions.Bson;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Objects;
@@ -25,7 +25,7 @@ public class ReadyMongoStatementTest {
     private ActivityDef activityDef;
     private StmtsDocList stmtsDocList;
 
-    @Before
+    @BeforeEach
     public void setup() {
         String[] params = {
                 "yaml=activities/mongodb-basic.yaml",

--- a/driver-stdout/src/test/java/io/nosqlbench/activitytype/stdout/StatementFormattersTest.java
+++ b/driver-stdout/src/test/java/io/nosqlbench/activitytype/stdout/StatementFormattersTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.activitytype.stdout;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 

--- a/driver-stdout/src/test/java/io/nosqlbench/activitytype/stdout/StdoutActivityTypeTest.java
+++ b/driver-stdout/src/test/java/io/nosqlbench/activitytype/stdout/StdoutActivityTypeTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.activitytype.stdout;
 import io.nosqlbench.engine.api.activityapi.core.Action;
 import io.nosqlbench.engine.api.activityapi.core.ActionDispenser;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by sebastianestevez on 5/5/17.

--- a/driver-web/src/test/java/io/nosqlbench/driver/webdriver/ExampleWebScript.java
+++ b/driver-web/src/test/java/io/nosqlbench/driver/webdriver/ExampleWebScript.java
@@ -1,8 +1,8 @@
 package io.nosqlbench.driver.webdriver;
 
 import io.nosqlbench.nb.api.testutils.Perf;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -18,7 +18,7 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 public class ExampleWebScript {
 
     @Test
-    @Ignore
+    @Disabled
     public void getDocsSiteChromeDriver() {
         System.setProperty("webdriver.http.factory", "okhttp");
         WebDriver driver = new ChromeDriver();
@@ -39,7 +39,7 @@ public class ExampleWebScript {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void getDocSiteWebHtml() {
 //        System.setProperty("webdriver.http.factory", "okhttp");
         WebDriver driver = new HtmlUnitDriver(false);

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ParameterMapTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ParameterMapTest.java
@@ -19,11 +19,12 @@
 package io.nosqlbench.engine.api.activityapi;
 
 import io.nosqlbench.engine.api.activityimpl.ParameterMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ParameterMapTest {
 
@@ -85,11 +86,12 @@ public class ParameterMapTest {
         assertThat(multiNames.get().getOptionalString("delta","gamma").orElse("missing")).isEqualTo("blue");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testAmbiguousMultiValueThrowsException() {
         Optional<ParameterMap> multiNames = ParameterMap.parseParams("alpha=blue;beta=red;delta=blue");
         assertThat(multiNames).isPresent();
-        assertThat(multiNames.get().getOptionalString("alpha","delta").orElse("missing")).isEqualTo("blue");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> multiNames.get().getOptionalString("alpha","delta"));
     }
 
     @Test

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/core/ops/fluent/OpTrackerImplTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/core/ops/fluent/OpTrackerImplTest.java
@@ -6,7 +6,7 @@ import io.nosqlbench.engine.api.activityapi.core.ops.fluent.opfacets.SucceededOp
 import io.nosqlbench.engine.api.activityapi.core.ops.fluent.opfacets.EventedOpImpl;
 import io.nosqlbench.engine.api.activityapi.core.ops.fluent.opfacets.StartedOp;
 import io.nosqlbench.engine.api.activityapi.core.ops.fluent.opfacets.TrackedOp;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpTrackerImplTest {
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/CycleResultsArraySegmentReadableTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/CycleResultsArraySegmentReadableTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.engine.api.activityapi.cyclelog;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResult;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultsSegment;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultSegmentBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.StreamSupport;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/CycleResultsRLEBufferReadableTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/CycleResultsRLEBufferReadableTest.java
@@ -21,7 +21,7 @@ import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResult
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultsSegment;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results_rle.CycleResultsRLEBufferReadable;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results_rle.CycleResultsRLEBufferTarget;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/CycleResultsRLEBufferTargetTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/CycleResultsRLEBufferTargetTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.engine.api.activityapi.cyclelog.buffers;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResult;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results_rle.CycleResultsRLEBufferReadable;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results_rle.CycleResultsRLEBufferTarget;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/results/CycleResultArraySegmentBufferTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/buffers/results/CycleResultArraySegmentBufferTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.StreamSupport;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/filters/tristate/EnumReadableMappingFilterTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/filters/tristate/EnumReadableMappingFilterTest.java
@@ -18,7 +18,7 @@
 package io.nosqlbench.engine.api.activityapi.cyclelog.filters.tristate;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.ResultReadable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/inputs/cyclelog/CycleLogInputTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/inputs/cyclelog/CycleLogInputTest.java
@@ -19,8 +19,8 @@ package io.nosqlbench.engine.api.activityapi.cyclelog.inputs.cyclelog;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleSegment;
 import io.nosqlbench.engine.api.activityapi.cyclelog.outputs.cyclelog.CycleLogOutput;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -31,7 +31,7 @@ public class CycleLogInputTest {
     private final static String filepath="cycle-log-reader-test";
     private static File cyclefile;
 
-    @BeforeClass
+    @BeforeAll
     public static void createTempFile() {
         try {
             cyclefile = File.createTempFile(filepath, "cyclelog");

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/tristate/CoreResultFilterTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/tristate/CoreResultFilterTest.java
@@ -22,7 +22,7 @@ import io.nosqlbench.engine.api.activityapi.cyclelog.filters.CoreResultValueFilt
 import io.nosqlbench.engine.api.activityapi.cyclelog.filters.ResultFilterDispenser;
 import io.nosqlbench.engine.api.activityapi.cyclelog.filters.ResultValueFilterType;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.MutableCycleResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/tristate/ResultFilteringSieveTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/cyclelog/tristate/ResultFilteringSieveTest.java
@@ -22,7 +22,7 @@ import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.ResultReada
 import io.nosqlbench.engine.api.activityapi.cyclelog.filters.tristate.ResultFilteringSieve;
 import io.nosqlbench.engine.api.activityapi.cyclelog.filters.tristate.TristateFilter;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.MutableCycleResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/errorhandling/HashedErrorHandlerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/errorhandling/HashedErrorHandlerTest.java
@@ -17,8 +17,8 @@
 
 package io.nosqlbench.engine.api.activityapi.errorhandling;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
@@ -26,19 +26,22 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class HashedErrorHandlerTest {
 
     HashedErrorHandler<Throwable, Boolean> handler;
 
-    @Before
+    @BeforeEach
     public void beforeTest() {
         handler = new HashedErrorHandler<Throwable,Boolean>();
     }
 
-    @Test(expected= RuntimeException.class)
+    @Test
     public void testDefaultHandlerThrowsException() {
-        handler.handleError(1L, new InvalidParameterException("this is an invalid exception, actually"));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
+            handler.handleError(1L, new InvalidParameterException("this is an invalid exception, actually"));
+        });
     }
 
     @Test
@@ -91,7 +94,7 @@ public class HashedErrorHandlerTest {
         assertThat(result).isFalse();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testNamedGroup() {
         handler.setGroup("test1",IndexOutOfBoundsException.class,ArrayIndexOutOfBoundsException.class);
         handler.setGroup("types",InvalidParameterException.class);
@@ -99,36 +102,41 @@ public class HashedErrorHandlerTest {
         assertThat(handler.getGroupNames()).hasSize(2);
         assertThat(handler.getGroupNames()).contains("test1");
         assertThat(handler.getGroupNames()).contains("types");
-        handler.handleError(5L,new InvalidParameterException("this is an error"));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+            handler.handleError(5L,new InvalidParameterException("this is an error")));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testFindVagueSingleSubmatchException() {
         handler.setGroup("index", IndexOutOfBoundsException.class, ArrayIndexOutOfBoundsException.class);
-        handler.setHandlerForPattern("Index", CycleErrorHandlers.rethrow("12345 678910 11 12"));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+                handler.setHandlerForPattern("Index", CycleErrorHandlers.rethrow("12345 678910 11 12")));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testFindMultipleRegex() {
         handler.setGroup("index", IndexOutOfBoundsException.class, ArrayIndexOutOfBoundsException.class);
         handler.setHandlerForPattern(".*Index.*", CycleErrorHandlers.rethrow("Journey through the klein bottle."));
-        Boolean result = handler.handleError(9L, new IndexOutOfBoundsException("9L was out of bounds"));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+            handler.handleError(9L, new IndexOutOfBoundsException("9L was out of bounds")));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testNonMatchingSubstringException() {
         handler.setGroup("index", IndexOutOfBoundsException.class, ArrayIndexOutOfBoundsException.class);
         Set<Class<? extends Throwable>> groups = handler.getGroup("index");
         assertThat(groups).isNotNull();
         assertThat(groups).hasSize(2);
         assertThat(groups.contains(IndexOutOfBoundsException.class)).isTrue();
-        handler.setHandlerForPattern("Dyahwemo", CycleErrorHandlers.rethrow("Journey through the klein bottle."));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+            handler.setHandlerForPattern("Dyahwemo", CycleErrorHandlers.rethrow("Journey through the klein bottle.")));
     }
 
-    @Test(expected=RuntimeException.class)
+    @Test
     public void testSetHandlerForMissingGroupException() {
         handler.setGroup("index", IndexOutOfBoundsException.class, ArrayIndexOutOfBoundsException.class);
-        handler.setHandlerForGroup("outdex", CycleErrorHandlers.rethrow("Journey through the klein bottle."));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+            handler.setHandlerForGroup("outdex", CycleErrorHandlers.rethrow("Journey through the klein bottle.")));
     }
 
     @Test

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/errorhandling/modular/NBErrorHandlerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/errorhandling/modular/NBErrorHandlerTest.java
@@ -6,22 +6,23 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import io.nosqlbench.engine.api.activityapi.errorhandling.ErrorMetrics;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class NBErrorHandlerTest {
 
     private final RuntimeException runtimeException = new RuntimeException("test exception");
 
-
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testNullConfig() {
         ErrorMetrics errorMetrics = new ErrorMetrics(ActivityDef.parseActivityDef("alias=testalias_stop"));
         NBErrorHandler errhandler = new NBErrorHandler(() -> "stop", () -> errorMetrics);
-        ErrorDetail detail = errhandler.handleError(runtimeException, 1, 2);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> errhandler.handleError(runtimeException, 1, 2));
     }
 
     @Test
@@ -90,6 +91,4 @@ public class NBErrorHandlerTest {
         assertThat(detail.isRetryable()).isFalse();
         assertThat(detail.resultCode).isEqualTo(42);
     }
-
-
 }

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/BucketSequencerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/BucketSequencerTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.api.activityapi.planning;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/ConcatSequencerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/ConcatSequencerTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityapi.planning;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/IntervalSequencerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/planning/IntervalSequencerTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityapi.planning;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/RateSpecTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/RateSpecTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityapi.ratelimits;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestHybridRateLimiterPerf.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestHybridRateLimiterPerf.java
@@ -20,8 +20,8 @@ package io.nosqlbench.engine.api.activityapi.ratelimits;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.nb.api.testutils.Perf;
 import io.nosqlbench.nb.api.testutils.Result;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
@@ -32,77 +32,77 @@ public class TestHybridRateLimiterPerf {
     private RateLimiterPerfTestMethods methods = new RateLimiterPerfTestMethods();
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e9() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E9, 1.1),10_000_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e8() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E8, 1.1),50_000_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e7() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E7, 1.1),5_000_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e6() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E6, 1.1),500_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e5() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E5, 1.1),50_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e4() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E4, 1.1),5_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e3() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E3, 1.1),500,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e2() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E2, 1.1),50,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e1() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E1, 1.1),5,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e0() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E0, 1.1),2,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testePerf1eN1() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E-1, 1.1),1,0.005d);
         System.out.println(result);
@@ -110,14 +110,14 @@ public class TestHybridRateLimiterPerf {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_160threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 10_000_000,160);
         System.out.println(perf.getLastResult());
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_80threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 10_000_000,80);
         System.out.println(perf.getLastResult());
@@ -130,7 +130,7 @@ public class TestHybridRateLimiterPerf {
     // JVM 11.0.1
     // 400000000_ops 33.622751_S 11896706.363_ops_s, 84_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_40threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 10_000_000,40);
         System.out.println(perf.getLastResult());
@@ -150,7 +150,7 @@ public class TestHybridRateLimiterPerf {
     // 200000000_ops 17.691698_S 11304737.461_ops_s, 88_ns_op
 
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_20threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 10_000_000,20);
         System.out.println(perf.getLastResult());
@@ -163,7 +163,7 @@ public class TestHybridRateLimiterPerf {
     // 200000000_ops 17.474475_S 11445264.894_ops_s, 87_ns_op
     // 200000000_ops 14.089247_S 14195222.897_ops_s, 70_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_10threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 10_000_000,10);
         System.out.println(perf.getLastResult());
@@ -177,7 +177,7 @@ public class TestHybridRateLimiterPerf {
     // JVM 11.0.1
     // 200000000_ops 11.839666_S 16892368.438_ops_s, 59_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_5threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 40_000_000,5);
         System.out.println(perf.getLastResult());

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerf1E7.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerf1E7.java
@@ -19,8 +19,8 @@ package io.nosqlbench.engine.api.activityapi.ratelimits;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.nb.api.testutils.Perf;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
@@ -40,7 +40,7 @@ public class TestRateLimiterPerf1E7 {
     // JVM 11.0.1
     // 160000000_ops 18.122886_S 8828615.971_ops_s, 113_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_160threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 1.1), 20_000_000,160);
         System.out.println(perf.getLastResult());
@@ -50,7 +50,7 @@ public class TestRateLimiterPerf1E7 {
     // JVM 11.0.1
     // 80000000_ops 8.354648_S 9575507.945_ops_s, 104_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_80threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 1.1), 20_000_000,80);
         System.out.println(perf.getLastResult());
@@ -60,7 +60,7 @@ public class TestRateLimiterPerf1E7 {
     // JVM 11.0.1
     // 40000000_ops 4.001661_S 9995849.116_ops_s, 100_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_40threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 1.1), 20_000_000,40);
         System.out.println(perf.getLastResult());
@@ -70,7 +70,7 @@ public class TestRateLimiterPerf1E7 {
     // JVM 11.0.1
     // 20000000_ops 1.914366_S 10447323.063_ops_s, 96_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_20threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 10), 20_000_000,20);
         System.out.println(perf.getLastResult());
@@ -84,7 +84,7 @@ public class TestRateLimiterPerf1E7 {
     // 100000000_ops 10.123873_S 9877642.338_ops_s, 101_ns_op
     // 100000000_ops 10.078673_S 9921941.517_ops_s, 101_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_10threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 1.1), 20_000_000,10);
         System.out.println(perf.getLastResult());
@@ -99,7 +99,7 @@ public class TestRateLimiterPerf1E7 {
     // 200000000_ops 19.761154_S 10120866.172_ops_s, 99_ns_op
     // 200000000_ops 19.928625_S 10035815.505_ops_s, 100_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test10Mops_5threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E7, 1.1), 20_000_000,5);
         System.out.println(perf.getLastResult());

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerf1E8.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerf1E8.java
@@ -19,8 +19,8 @@ package io.nosqlbench.engine.api.activityapi.ratelimits;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.nb.api.testutils.Perf;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
@@ -44,7 +44,7 @@ public class TestRateLimiterPerf1E8 {
     // 1600000000_ops 158.224286_S 10_112_227.620_ops_s, 99_ns_op
     //
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_160threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,160);
         System.out.println(perf.getLastResult());
@@ -55,7 +55,7 @@ public class TestRateLimiterPerf1E8 {
     // 800000000_ops 74.104295_S 10795595.534_ops_s, 93_ns_op
     // 800000000_ops 74.155495_S 10788141.933_ops_s, 93_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_80threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,80);
         System.out.println(perf.getLastResult());
@@ -68,7 +68,7 @@ public class TestRateLimiterPerf1E8 {
     // JVM 11.0.1, Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
     // 400000000_ops 33.622751_S 11896706.363_ops_s, 84_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_40threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,40);
         System.out.println(perf.getLastResult());
@@ -88,7 +88,7 @@ public class TestRateLimiterPerf1E8 {
     // 200000000_ops 17.691698_S 11304737.461_ops_s, 88_ns_op
 
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_20threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,20);
         System.out.println(perf.getLastResult());
@@ -104,7 +104,7 @@ public class TestRateLimiterPerf1E8 {
     // 100000000_ops 7.751758_S 12900299.587_ops_s, 78_ns_op
     // 100000000_ops 7.864851_S 12714799.657_ops_s, 79_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_10threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,10);
         System.out.println(perf.getLastResult());
@@ -121,7 +121,7 @@ public class TestRateLimiterPerf1E8 {
     // 100000000_ops 6.317008_S 15830279.182_ops_s, 63_ns_op
     // 200000000_ops 13.551712_S 14758282.931_ops_s, 68_ns_op
     @Test
-    @Ignore
+    @Disabled
     public void test100Mops_5threads() {
         Perf perf = methods.testRateLimiterMultiThreadedContention(rlFunction, new RateSpec(1E8, 1.1), 100_000_000,5);
         System.out.println(perf.getLastResult());

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerfSingle.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TestRateLimiterPerfSingle.java
@@ -19,8 +19,8 @@ package io.nosqlbench.engine.api.activityapi.ratelimits;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.nb.api.testutils.Result;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
@@ -37,77 +37,77 @@ public class TestRateLimiterPerfSingle {
     private RateLimiterPerfTestMethods methods = new RateLimiterPerfTestMethods();
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e9() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E9, 1.1),10_000_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e8() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E8, 1.1),50_000_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e7() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E7, 1.1),5_000_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e6() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E6, 1.1),500_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e5() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E5, 1.1),50_000,0.01d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e4() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E4, 1.1),5_000,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e3() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E3, 1.1),500,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e2() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E2, 1.1),50,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e1() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E1, 1.1),5,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPerf1e0() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E0, 1.1),2,0.005d);
         System.out.println(result);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testePerf1eN1() {
         Result result = methods.rateLimiterSingleThreadedConvergence(rlFunction,new RateSpec(1E-1, 1.1),1,0.005d);
         System.out.println(result);

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TokenPoolTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/TokenPoolTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityapi.ratelimits;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.activityimpl.ParameterMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/sysperf/SysPerfBaselinerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/sysperf/SysPerfBaselinerTest.java
@@ -17,13 +17,13 @@
 
 package io.nosqlbench.engine.api.activityapi.sysperf;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class SysPerfBaselinerTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testSysOpsNanoTime() {
         SysPerfBaseliner sbo = new SysPerfBaseliner();
         SysPerfData perfdata = sbo.getSysPerfData();

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/sysperf/SysPerfTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityapi/sysperf/SysPerfTest.java
@@ -17,8 +17,8 @@
 
 package io.nosqlbench.engine.api.activityapi.sysperf;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.attribute.FileTime;
 import java.util.Optional;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SysPerfTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testForcedBench() {
 
 //        SysPerf.get().reset();

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/MultiMapLookupTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/MultiMapLookupTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityconfig;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/BindingEscapingTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/BindingEscapingTest.java
@@ -21,7 +21,7 @@ import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/OpDefTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/OpDefTest.java
@@ -22,7 +22,7 @@ import io.nosqlbench.engine.api.activityconfig.yaml.OpTemplate;
 import io.nosqlbench.engine.api.activityconfig.yaml.StmtsBlock;
 import io.nosqlbench.engine.api.activityconfig.yaml.StmtsDoc;
 import io.nosqlbench.engine.api.activityconfig.yaml.StmtsDocList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/RawYamlStatementLoaderTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/RawYamlStatementLoaderTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityconfig.rawyaml;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/StmtEscapingTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/StmtEscapingTest.java
@@ -19,10 +19,10 @@ package io.nosqlbench.engine.api.activityconfig.rawyaml;
 
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import io.nosqlbench.engine.api.activityconfig.yaml.*;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public class StmtEscapingTest {
     private final static Logger logger = LogManager.getLogger(StmtEscapingTest.class);
     private static List<OpTemplate> defs;
 
-    @BeforeClass
+    @BeforeAll
     public static void testLayering() {
 
         StmtsDocList all = StatementsLoader.loadPath(logger, "testdocs/escaped_stmts.yaml");

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/StmtVariationTests.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/rawyaml/StmtVariationTests.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityconfig.rawyaml;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/ParsedStmtTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/ParsedStmtTest.java
@@ -19,10 +19,10 @@ package io.nosqlbench.engine.api.activityconfig.yaml;
 
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import io.nosqlbench.engine.api.activityconfig.ParsedStmt;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +30,7 @@ public class ParsedStmtTest {
     private static final Logger logger = LogManager.getLogger(ParsedStmtTest.class);
     private static StmtsDocList doclist;
 
-    @BeforeClass
+    @BeforeAll
     public static void testLoadYaml() {
         doclist = StatementsLoader.loadPath(logger, "testdocs/bindings.yaml");
     }

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/StmtDetailOverrideTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/StmtDetailOverrideTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.engine.api.activityconfig.yaml;
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/StmtsDocListTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityconfig/yaml/StmtsDocListTest.java
@@ -19,10 +19,10 @@ package io.nosqlbench.engine.api.activityconfig.yaml;
 
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import org.assertj.core.data.MapEntry;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,7 +49,7 @@ public class StmtsDocListTest {
     }};
 
 
-    @BeforeClass
+    @BeforeAll
     public static void testLoadYaml() {
         doclist = StatementsLoader.loadPath(logger, "testdocs/docs_blocks_stmts.yaml");
     }

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/ActivityDefTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/ActivityDefTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityimpl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/CpuInfoTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/CpuInfoTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityimpl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/AtomicInputTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/AtomicInputTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityimpl.input;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleSegment;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/CycleArrayBufferTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/CycleArrayBufferTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityimpl.input;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleArray;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleSegment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/CycleArrayTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/CycleArrayTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityimpl.input;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleArray;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleSegment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/InputIntervalTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/input/InputIntervalTest.java
@@ -18,7 +18,7 @@
 package io.nosqlbench.engine.api.activityimpl.input;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleSegment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/ByteTrackerExtentTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/ByteTrackerExtentTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.activityimpl.marker;
 
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResult;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultsSegment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/CoreOutputAtticTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/CoreOutputAtticTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.activityimpl.marker;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoreOutputAtticTest {
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/CoreOutputTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/marker/CoreOutputTest.java
@@ -21,7 +21,7 @@ import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResult
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultSegmentBuffer;
 import io.nosqlbench.engine.api.activityapi.cyclelog.buffers.results.CycleResultsSegment;
 import io.nosqlbench.engine.api.activityapi.output.Output;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/tracking/LongTreeTrackerTest2.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/tracking/LongTreeTrackerTest2.java
@@ -2,8 +2,8 @@ package io.nosqlbench.engine.api.activityimpl.tracking;
 
 import io.nosqlbench.engine.api.activityimpl.marker.longheap.LongTreeTracker;
 import io.nosqlbench.engine.api.activityimpl.marker.longheap.LongTreeTrackerAtomic;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -139,7 +139,7 @@ public class LongTreeTrackerTest2 {
      */
 
     @Test
-    @Ignore
+    @Disabled
     public void speedcheckThreadLocal() {
         long t1=System.nanoTime();
         LongTreeTracker t = new LongTreeTracker();
@@ -159,7 +159,7 @@ public class LongTreeTrackerTest2 {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void speedcheckConcurrentLocal() {
         long t1=System.nanoTime();
         LongTreeTracker t = new LongTreeTrackerAtomic();

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/tracking/TreeTracker1024Test.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/activityimpl/tracking/TreeTracker1024Test.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.engine.api.activityimpl.tracking;
 
 import io.nosqlbench.engine.api.activityimpl.marker.longheap.TreeTracker1024;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/clireader/CLITest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/clireader/CLITest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.api.clireader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/ActivityMetricsTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/ActivityMetricsTest.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.api.metrics;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/DeltaHdrHistogramReservoirTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/DeltaHdrHistogramReservoirTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.engine.api.metrics;
 
 import com.codahale.metrics.Snapshot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DeltaHdrHistogramReservoirTest {
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/HistoIntervalLoggerTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/HistoIntervalLoggerTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.engine.api.metrics;
 import org.HdrHistogram.EncodableHistogram;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.HistogramLogReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/NicerHistogramTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/NicerHistogramTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/TestHistoTypes.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/metrics/TestHistoTypes.java
@@ -2,13 +2,13 @@ package io.nosqlbench.engine.api.metrics;
 
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Snapshot;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestHistoTypes {
 
     @Test
-    @Ignore
+    @Disabled
     public void compareHistos() {
         Clock c = new Clock();
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/scripting/GraalJsEvaluatorTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/scripting/GraalJsEvaluatorTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/templating/CommandTemplateTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/templating/CommandTemplateTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.engine.api.templating;
 import io.nosqlbench.engine.api.activityconfig.StatementsLoader;
 import io.nosqlbench.engine.api.activityconfig.yaml.OpTemplate;
 import io.nosqlbench.engine.api.activityconfig.yaml.StmtsDocList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/templating/StrInterpolatorTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/templating/StrInterpolatorTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.templating;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/util/SSLKsFactoryTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/util/SSLKsFactoryTest.java
@@ -18,7 +18,7 @@
 package io.nosqlbench.engine.api.util;
 
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/util/SimpleConfigTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/util/SimpleConfigTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/util/TagFilterTest.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/util/TagFilterTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.api.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/engine-api/src/test/java/io/nosqlbench/engine/api/util/UnitParserTests.java
+++ b/engine-api/src/test/java/io/nosqlbench/engine/api/util/UnitParserTests.java
@@ -18,7 +18,7 @@
 package io.nosqlbench.engine.api.util;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/BasicScriptBufferTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/BasicScriptBufferTest.java
@@ -1,10 +1,11 @@
 package io.nosqlbench.engine.cli;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class BasicScriptBufferTest {
 
@@ -62,14 +63,9 @@ public class BasicScriptBufferTest {
         assertThat(script).matches("(?s).*a single line.*");
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void shouldThrowErrorForInvalidWaitMillisOperand() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{ "waitmillis", "noway" });
-        BasicScriptBuffer b = new BasicScriptBuffer();
-        b.add(opts.getCommands().toArray(new Cmd[0]));
-        String s = b.getParsedScript();
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{ "waitmillis", "noway" }));
     }
-
-
-
 }

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/CmdTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/CmdTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.cli;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIArgsFileTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIArgsFileTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.cli;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class NBCLIArgsFileTest {
 
@@ -30,11 +31,11 @@ public class NBCLIArgsFileTest {
         System.out.println(result);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testLoadingMissingRequiredFails() {
-        LinkedList<String> result;
         NBCLIArgsFile argsFile = new NBCLIArgsFile();
-        result = argsFile.process("--argsfile-required", "src/test/resources/argsfiles/nonextant.cli");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> argsFile.process("--argsfile-required", "src/test/resources/argsfiles/nonextant.cli"));
     }
 
     @Test

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioParserTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioParserTest.java
@@ -2,11 +2,12 @@ package io.nosqlbench.engine.cli;
 
 import io.nosqlbench.engine.api.scenarios.NBCLIScenarioParser;
 import io.nosqlbench.nb.api.errors.BasicError;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class NBCLIScenarioParserTest {
 
@@ -49,15 +50,16 @@ public class NBCLIScenarioParserTest {
         assertThat(cmds.get(0).getArg("driver")).isEqualTo("stdout");
     }
 
-    @Test(expected = BasicError.class)
+    @Test
     public void testThatVerboseFinalParameterThrowsError() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{ "scenario-test", "yaml=canttouchthis"});
-        List<Cmd> cmds = opts.getCommands();
+        assertThatExceptionOfType(BasicError.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{ "scenario-test", "yaml=canttouchthis"}));
     }
 
-    @Test(expected = BasicError.class)
+    @Test
     public void testThatMissingScenarioNameThrowsError() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{ "scenario-test", "missing-scenario"});
+        assertThatExceptionOfType(BasicError.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{ "scenario-test", "missing-scenario"}));
     }
 
     @Test

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/SessionNamerTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/SessionNamerTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.engine.cli;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/TestNBCLIOptions.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/TestNBCLIOptions.java
@@ -2,7 +2,7 @@ package io.nosqlbench.engine.cli;
 
 import io.nosqlbench.docsys.core.PathWalker;
 import io.nosqlbench.nb.api.content.NBIO;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class TestNBCLIOptions {
 
@@ -87,9 +88,10 @@ public class TestNBCLIOptions {
         assertThat(opts.wantsTopicalHelp()).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldErrorSanelyWhenNoMatch() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{"unrecognizable command"});
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{"unrecognizable command"}));
     }
 
     @Test
@@ -102,14 +104,16 @@ public class TestNBCLIOptions {
         assertThat(cmd.getParams().get("param1")).isEqualTo("value1");
     }
 
-    @Test(expected = InvalidParameterException.class)
+    @Test
     public void testShouldErrorSanelyWhenScriptNameSkipped() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{"script", "param1=value1"});
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{"script", "param1=value1"}));
     }
 
-    @Test(expected = InvalidParameterException.class)
+    @Test
     public void testShouldErrorForMissingScriptName() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{"script"});
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{"script"}));
     }
 
     @Test
@@ -140,10 +144,10 @@ public class TestNBCLIOptions {
 
     }
 
-    @Test(expected = InvalidParameterException.class)
+    @Test
     public void shouldThrowErrorForInvalidStopActivity() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{ "stop", "woah=woah" });
-        List<Cmd> cmds = opts.getCommands();
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{ "stop", "woah=woah" }));
     }
 
     @Test
@@ -155,11 +159,10 @@ public class TestNBCLIOptions {
 
     }
 
-    @Test(expected = InvalidParameterException.class)
+    @Test
     public void shouldThrowErrorForInvalidAwaitActivity() {
-        NBCLIOptions opts = new NBCLIOptions(new String[]{ "await", "awaitme=notvalid" });
-        List<Cmd> cmds = opts.getCommands();
-
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(() -> new NBCLIOptions(new String[]{ "await", "awaitme=notvalid" }));
     }
 
     @Test

--- a/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/GTimeUnitTest.java
+++ b/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/GTimeUnitTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.engine.clients.grafana;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/GrafanaClientTest.java
+++ b/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/GrafanaClientTest.java
@@ -1,8 +1,8 @@
 package io.nosqlbench.engine.clients.grafana;
 
 import io.nosqlbench.engine.clients.grafana.transfer.GAnnotation;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -10,7 +10,7 @@ public class GrafanaClientTest {
     private static final String testurl = "http://localhost:3000/";
 
     @Test
-    @Ignore
+    @Disabled
     public void testCreateAnnotation() {
         GrafanaClient client = new GrafanaClient(testurl);
         client.getConfig().basicAuth("admin", "admin");
@@ -22,7 +22,7 @@ public class GrafanaClientTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testFindAnnotations() {
         GrafanaClient client = new GrafanaClient(testurl);
         client.getConfig().basicAuth("admin", "admin");
@@ -31,7 +31,7 @@ public class GrafanaClientTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testGetApiToken() {
         GrafanaClient client = new GrafanaClient(testurl);
         client.getConfig().basicAuth("admin", "admin");

--- a/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/analyzer/GrafanaRegionAnalyzerTest.java
+++ b/engine-clients/src/test/java/io/nosqlbench/engine/clients/grafana/analyzer/GrafanaRegionAnalyzerTest.java
@@ -1,13 +1,13 @@
 package io.nosqlbench.engine.clients.grafana.analyzer;
 
 import io.nosqlbench.engine.clients.grafana.transfer.GDashboard;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class GrafanaRegionAnalyzerTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testGetQueries() {
         GrafanaRegionAnalyzer gra = new GrafanaRegionAnalyzer();
         gra.setBaseUrl("http://44.242.139.57:3000/");

--- a/engine-clients/src/test/java/io/nosqlbench/engine/clients/prometheus/PMatrixElemTest.java
+++ b/engine-clients/src/test/java/io/nosqlbench/engine/clients/prometheus/PMatrixElemTest.java
@@ -4,8 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import io.nosqlbench.nb.api.content.NBIO;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PMatrixElemTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testMatrixElem() {
         Gson gson = new GsonBuilder().create();
         String json = NBIO.classpath().name("test.json").one().asString();

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/ActivityExecutorTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/ActivityExecutorTest.java
@@ -15,7 +15,7 @@ import io.nosqlbench.engine.api.activityimpl.motor.CoreMotorDispenser;
 import io.nosqlbench.engine.core.lifecycle.ActivityExecutor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/CoreMotorTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/CoreMotorTest.java
@@ -5,7 +5,7 @@ import io.nosqlbench.engine.core.fortesting.BlockingSegmentInput;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.activityimpl.SimpleActivity;
 import io.nosqlbench.engine.api.activityimpl.motor.CoreMotor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/ScenarioTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/ScenarioTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.engine.core;
 
 import io.nosqlbench.engine.api.scripting.ScriptEnvBuffer;
 import io.nosqlbench.engine.core.script.Scenario;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/experimental/CompletableTests.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/experimental/CompletableTests.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.core.experimental;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/metrics/NBMetricsSummaryTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/metrics/NBMetricsSummaryTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.engine.core.metrics;
 
 import com.codahale.metrics.Timer;
 import io.nosqlbench.engine.api.metrics.DeltaHdrHistogramReservoir;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScenarioContextBufferTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScenarioContextBufferTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.engine.core.script;
 
 import io.nosqlbench.engine.api.scripting.ScriptEnvBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScenariosExecutorTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScenariosExecutorTest.java
@@ -18,13 +18,13 @@
 package io.nosqlbench.engine.core.script;
 
 import io.nosqlbench.engine.core.lifecycle.ScenariosResults;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ScenariosExecutorTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testAwaitOnTime() {
         ScenariosExecutor e = new ScenariosExecutor(ScenariosExecutorTest.class.getSimpleName(), 1);
         Scenario s = new Scenario("testing", Scenario.Engine.Graalvm,"stdout:3000");

--- a/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScriptParamsTest.java
+++ b/engine-core/src/test/java/io/nosqlbench/engine/core/script/ScriptParamsTest.java
@@ -1,23 +1,25 @@
 package io.nosqlbench.engine.core.script;
 
 import io.nosqlbench.nb.api.errors.BasicError;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ScriptParamsTest {
 
-    @Test(expected = BasicError.class)
+    @Test
     public void testThatNullOverridesKeyThrowsBasicError() {
         ScriptParams p = new ScriptParams();
         p.putAll(Map.of("a","b"));
         p.withDefaults(Map.of("c","d"));
         HashMap<String, String> overrides = new HashMap<>();
         overrides.put(null,"test");
-        p.withOverrides(overrides);
+        assertThatExceptionOfType(BasicError.class)
+                .isThrownBy(() -> p.withOverrides(overrides));
     }
 
 }

--- a/engine-extensions/src/test/java/io/nosqlbench/optimizers/TestOptimoExperiments.java
+++ b/engine-extensions/src/test/java/io/nosqlbench/optimizers/TestOptimoExperiments.java
@@ -21,7 +21,7 @@ import org.apache.commons.math3.optim.*;
 import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
 import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.BOBYQAOptimizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/engine-rest/src/test/java/io/nosqlbench/engine/rest/services/openapi/OpenApiLoaderTest.java
+++ b/engine-rest/src/test/java/io/nosqlbench/engine/rest/services/openapi/OpenApiLoaderTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.engine.rest.services.openapi;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpenApiLoaderTest {
 

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -375,12 +375,6 @@
       <version>5.6.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>5.6.2</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -353,7 +353,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.15.0</version>
+      <version>3.19.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -27,7 +27,7 @@
     <jaxb.impl.version>2.4.0-b180830.0438</jaxb.impl.version>
     <jmh.version>1.22</jmh.version>
     <joda.time.version>2.9.9</joda.time.version>
-    <junit.jupiter.version>5.3.2</junit.jupiter.version>
+    <junit.jupiter.version>5.7.2</junit.jupiter.version>
 
     <lz4.version>1.4.1</lz4.version>
 <!--    <metrics.version>4.0.7</metrics.version>-->
@@ -88,7 +88,7 @@
 
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <version>5.6.2</version>
+        <version>${junit.jupiter.version}</version>
         <artifactId>junit-jupiter</artifactId>
         <scope>test</scope>
       </dependency>
@@ -208,7 +208,6 @@
         <artifactId>oshi-core</artifactId>
         <version>5.2.2</version>
       </dependency>
-
 
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -361,18 +360,13 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.6.2</version>
+      <version>1.7.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.6.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.2</version>
+      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/nb-api/src/test/java/io/nosqlbench/engine/api/activityimpl/motor/ParamsParserTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/engine/api/activityimpl/motor/ParamsParserTest.java
@@ -18,11 +18,12 @@
 package io.nosqlbench.engine.api.activityimpl.motor;
 
 import io.nosqlbench.nb.api.config.ParamsParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ParamsParserTest {
 
@@ -60,7 +61,6 @@ public class ParamsParserTest {
         assertThat(p).hasSize(2);
         assertThat(p).containsKey("b");
         assertThat(p.get("b")).isEqualTo("fo'urfive");
-
     }
 
     @Test
@@ -127,7 +127,6 @@ public class ParamsParserTest {
         assertThat(p).containsKey("b");
         assertThat(p.get("a")).isEqualTo("1");
         assertThat(p.get("b")).isEqualTo("2");
-
     }
 
     @Test
@@ -138,7 +137,6 @@ public class ParamsParserTest {
         assertThat(p).containsKey("b");
         assertThat(p.get("a")).isEqualTo("1 2 3");
         assertThat(p.get("b")).isEqualTo("2");
-
     }
 
     @Test
@@ -149,17 +147,12 @@ public class ParamsParserTest {
         assertThat(p).containsKey("b");
         assertThat(p.get("a")).isEqualTo("1");
         assertThat(p.get("b")).isEqualTo("2 3 4");
-
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testValidNameException() {
-        Map<String, String> p = ParamsParser.parse("a=1\\\\;'\";b=2 3 4",true);
-        assertThat(p).hasSize(2);
-        assertThat(p).containsKey("a");
-        assertThat(p).containsKey("b");
-        assertThat(p.get("a")).isEqualTo("1\\;'\"");
-        assertThat(p.get("b")).isEqualTo("2 3 4");
+    @Test
+    public void testInvalidNameException() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> ParamsParser.parse("a=1\\\\;'\";b=2 3 4",true));
     }
 
     @Test
@@ -170,8 +163,6 @@ public class ParamsParserTest {
         assertThat(p).containsKey("b");
         assertThat(p.get("a")).isEqualTo("fiver");
         assertThat(p.get("b")).isEqualTo(" sixer");
-
     }
-
 
 }

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/NBEnvironmentTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/NBEnvironmentTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/SystemIdTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/SystemIdTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SystemIdTest {
 

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/annotations/AnnotationBuilderTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/annotations/AnnotationBuilderTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api.annotations;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/config/ConfigLoaderTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/config/ConfigLoaderTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/config/SynonymsTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/config/SynonymsTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/config/params/NBParamsTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/config/params/NBParamsTest.java
@@ -1,8 +1,8 @@
 package io.nosqlbench.nb.api.config.params;
 
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
@@ -36,7 +36,7 @@ public class NBParamsTest {
     }
 
     @Test
-    @Ignore("This case is unwieldy and generally not useful")
+    @Disabled("This case is unwieldy and generally not useful")
     public void testNestedMixedJsonParamsMap() {
         Element one = NBParams.one("{\"key1\":\"key2={\"key3\":\"value3\",\"key4\":\"value4\"}\"}");
         assertThat(one.get("key1.key2.key3", String.class)).isPresent();

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/content/NBIOTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/content/NBIOTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.nb.api.content;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/markdown/aggregator/MarkdownDocsTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/markdown/aggregator/MarkdownDocsTest.java
@@ -2,8 +2,8 @@ package io.nosqlbench.nb.api.markdown.aggregator;
 
 import io.nosqlbench.nb.api.content.PathContent;
 import io.nosqlbench.nb.api.markdown.types.MarkdownInfo;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.nio.file.*;
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.from;
 public class MarkdownDocsTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testLoadMarkdown() {
         List<MarkdownInfo> processed = MarkdownDocs.findAll();
         List<MarkdownInfo> expected = fromRaw("docs-for-testing-logical");

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/pathutil/ResolverForURLTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/pathutil/ResolverForURLTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.nb.api.content.Content;
 import io.nosqlbench.nb.api.content.ResolverForClasspath;
 import io.nosqlbench.nb.api.content.ResolverForFilesystem;
 import io.nosqlbench.nb.api.content.ResolverForURL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.nio.file.Path;

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/testutils/BoundsTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/testutils/BoundsTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.nb.api.testutils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb-api/src/test/java/io/nosqlbench/nb/api/testutils/PerfTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/nb/api/testutils/PerfTest.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.nb.api.testutils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb/src/test/java/io/nosqlbench/cli/testing/ExitStatusIntegrationTests.java
+++ b/nb/src/test/java/io/nosqlbench/cli/testing/ExitStatusIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package io.nosqlbench.cli.testing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/AsyncScriptIntegrationTests.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/AsyncScriptIntegrationTests.java
@@ -21,8 +21,8 @@ import io.nosqlbench.engine.core.lifecycle.ScenarioResult;
 import io.nosqlbench.engine.core.lifecycle.ScenariosResults;
 import org.apache.commons.compress.utils.IOUtils;
 import org.assertj.core.data.Offset;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,7 +73,7 @@ public class AsyncScriptIntegrationTests {
         return scenarioResult;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void logit() {
         System.out.println("Running ASYNC version of Script Integration Tests.");
     }
@@ -265,7 +265,7 @@ public class AsyncScriptIntegrationTests {
 
 
 //    @Test
-//    @Ignore
+//    @Disabled
 //    public void testCycleRateChangeOldMetrics() {
 //        ScenarioResult scenarioResult = runScenario("cycle_rate_change_deprecated");
 //        String ioLog = scenarioResult.getIOLog();

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/MetricsIntegrationTest.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/MetricsIntegrationTest.java
@@ -20,7 +20,7 @@ package io.nosqlbench.engine.core.script;
 import com.codahale.metrics.Histogram;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.metrics.ActivityMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/MetricsMapperIntegrationTest.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/MetricsMapperIntegrationTest.java
@@ -15,7 +15,7 @@
 
 package io.nosqlbench.engine.core.script;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/NBCliIntegrationTests.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/NBCliIntegrationTests.java
@@ -19,7 +19,7 @@ package io.nosqlbench.engine.core.script;
 
 import io.nosqlbench.cli.testing.ProcessInvoker;
 import io.nosqlbench.cli.testing.ProcessResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/ScriptIntegrationTests.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/ScriptIntegrationTests.java
@@ -21,8 +21,8 @@ import io.nosqlbench.engine.core.lifecycle.ScenarioResult;
 import io.nosqlbench.engine.core.lifecycle.ScenariosResults;
 import org.apache.commons.compress.utils.IOUtils;
 import org.assertj.core.data.Offset;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,7 +68,7 @@ public class ScriptIntegrationTests {
     }
 
 
-    @BeforeClass
+    @BeforeAll
     public static void logit() {
         System.out.println("Running SYNC version of Script Integration Tests.");
     }

--- a/nb/src/test/java/io/nosqlbench/engine/core/script/SpeedCheckIntegrationTests.java
+++ b/nb/src/test/java/io/nosqlbench/engine/core/script/SpeedCheckIntegrationTests.java
@@ -15,8 +15,8 @@
 package io.nosqlbench.engine.core.script;
 
 import io.nosqlbench.engine.core.lifecycle.ScenarioResult;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -26,13 +26,13 @@ import org.junit.Test;
 public class SpeedCheckIntegrationTests {
 
     @Test
-    @Ignore
+    @Disabled
     public void testSpeedSanity() {
         ScenarioResult scenarioResult = ScriptIntegrationTests.runScenario("speedcheck");
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testThreadSpeeds() {
         ScenarioResult scenarioResult = ScriptIntegrationTests.runScenario("threadspeeds");
     }

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/annotations/ExampleDataTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/annotations/ExampleDataTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.annotations;
 
 import io.nosqlbench.virtdata.api.annotations.ExampleData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/api/bindings/VirtDataConversionsTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/api/bindings/VirtDataConversionsTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.api.bindings;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.*;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/CompatibilityFixupsTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/CompatibilityFixupsTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.core;
 
 import io.nosqlbench.virtdata.core.bindings.CompatibilityFixups;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/ResolvedFunctionTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/ResolvedFunctionTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.core;
 
 import io.nosqlbench.virtdata.core.bindings.ResolvedFunction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.LongUnaryOperator;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/VirtDataComposerTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/VirtDataComposerTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.core;
 
 import io.nosqlbench.virtdata.core.bindings.ResolverDiagnostics;
 import io.nosqlbench.virtdata.core.bindings.VirtDataComposer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VirtDataComposerTest {
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/VirtDataTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/VirtDataTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.core;
 
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/composers/FunctionAssemblerMatrixTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/composers/FunctionAssemblerMatrixTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.virtdata.core.composers;
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.FunctionType;
 import io.nosqlbench.virtdata.core.bindings.DataMapperFunctionMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/composers/FunctionAssemblerTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/composers/FunctionAssemblerTest.java
@@ -1,13 +1,14 @@
 package io.nosqlbench.virtdata.core.composers;
 
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FunctionAssemblerTest {
 
@@ -51,13 +52,14 @@ public class FunctionAssemblerTest {
         assertThat(aLong).isEqualTo(15);
     }
 
-    @Test(expected = ClassCastException.class)
-    public void testLongFunctionLongFunctionMistyped() throws Exception {
+    @Test
+    public void testLongFunctionLongFunctionMistyped() {
         FunctionComposer fass = new FunctionAssembly();
         fass.andThen(new LongAddFiveFunction());
         fass.andThen(new GenericStringCat());
         DataMapper<String> dataMapper = fass.getDataMapper();
-        dataMapper.get(5);
+        assertThatExceptionOfType(ClassCastException.class)
+                .isThrownBy(() -> dataMapper.get(5));
     }
 
     @Test
@@ -79,12 +81,13 @@ public class FunctionAssemblerTest {
 //        assertThat(s).isEqualTo("Cat5");
 //    }
 
-    @Test(expected= ClassCastException.class)
+    @Test
     public void testFunctionFunctionMistyped() {
         FunctionComposer fass = new FunctionAssembly();
         fass.andThen(new GenericStringCat());
         DataMapper<String> dataMapper = fass.getDataMapper();
-        String s = dataMapper.get(5);
+        assertThatExceptionOfType(ClassCastException.class)
+                .isThrownBy(() -> dataMapper.get(5));
     }
 
     @Test

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/config/ConfigDataTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/config/ConfigDataTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.core.config;
 
 import io.nosqlbench.nb.api.config.ConfigData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/ParsedTemplateTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/ParsedTemplateTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.core.templates;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;
 import java.util.HashMap;
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ParsedTemplateTest {
 
@@ -39,7 +40,7 @@ public class ParsedTemplateTest {
         assertThat(pt.getExtraBindings()).hasSameElementsAs(bindings.keySet());
     }
 
-    @Ignore("currently not working correctly")
+    @Disabled("currently not working correctly")
     @Test
     public void testShouldMatchQuestionMark() {
         ParsedTemplate pt = new ParsedTemplate(oneQuestion, bindings);
@@ -90,11 +91,12 @@ public class ParsedTemplateTest {
     }
 
     //, expectedExceptionsMessageRegExp = ".*must contain a named group called anchor.*"
-    @Test(expected= InvalidParameterException.class)
+    @Test
     public void testShouldErrorOnInvalidPattern() {
         String wontuse = "This won't get used.";
         Pattern p = Pattern.compile("\\[(\\w[_a-zA-Z]+)]");
-        ParsedTemplate pt = new ParsedTemplate(wontuse, bindings, p);
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(()-> new ParsedTemplate(wontuse, bindings, p));
     }
 
     @Test

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/StringBindingsTemplateTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/StringBindingsTemplateTest.java
@@ -1,18 +1,20 @@
 package io.nosqlbench.virtdata.core.templates;
 
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class StringBindingsTemplateTest {
 
     // , expectedExceptionsMessageRegExp = ".*not provided in the bindings: \\[two, three\\]")
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testUnqualifiedBindings() {
         BindingsTemplate bt1 = new BindingsTemplate();
         bt1.addFieldBinding("one", "Identity()");
         String template="{one} {two} {three}\n";
         StringBindingsTemplate sbt = new StringBindingsTemplate(template,bt1);
-        StringBindings resolved = sbt.resolve();
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(sbt::resolve);
     }
-
 }

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/StringCompositorTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/StringCompositorTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.core.templates;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/ValueTypeTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/core/templates/ValueTypeTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.core.templates;
 
 import io.nosqlbench.virtdata.core.bindings.ValueType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/testmappers/TestableTemplateTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/testmappers/TestableTemplateTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.testmappers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/util/StringObjectPromoterTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/util/StringObjectPromoterTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.util;
 
 import io.nosqlbench.virtdata.core.bindings.StringObjectPromoter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/virtdata-api/src/test/java/io/nosqlbench/virtdata/util/VirtDataFunctionsTest.java
+++ b/virtdata-api/src/test/java/io/nosqlbench/virtdata/util/VirtDataFunctionsTest.java
@@ -1,11 +1,13 @@
 package io.nosqlbench.virtdata.util;
 
 import io.nosqlbench.virtdata.api.bindings.VirtDataFunctions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;
 import java.util.function.Function;
 import java.util.function.LongFunction;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class VirtDataFunctionsTest  {
 
@@ -16,11 +18,10 @@ public class VirtDataFunctionsTest  {
         long f2 = adapted.apply(42L);
     }
 
-    @Test(expected = InvalidParameterException.class)
+    @Test
     public void testWrongLongUnaryConversion() {
-        Function<Long,Integer> fl = (Long l) -> Math.max(l.intValue(),43);
-        LongFunction<Long> adapted = VirtDataFunctions.adapt(fl, LongFunction.class, Long.class, true);
-        long f2 = adapted.apply(42L);
+        Function<Long,Integer> fl = (Long l) -> Math.max(l.intValue(), 43);
+        assertThatExceptionOfType(InvalidParameterException.class)
+                .isThrownBy(() -> VirtDataFunctions.adapt(fl, LongFunction.class, Long.class, true));
     }
-
 }

--- a/virtdata-lang/src/test/java/io/nosqlbench/virtdata/lang/parser/VirtdataBuilderTest.java
+++ b/virtdata-lang/src/test/java/io/nosqlbench/virtdata/lang/parser/VirtdataBuilderTest.java
@@ -6,7 +6,7 @@ import io.nosqlbench.virtdata.lang.generated.VirtDataParser;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CodePointCharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/lfsrs/MetaShiftTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/lfsrs/MetaShiftTest.java
@@ -1,8 +1,9 @@
 package io.nosqlbench.virtdata.library.basics.core.lfsrs;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MetaShiftTest {
 
@@ -14,9 +15,10 @@ public class MetaShiftTest {
         assertThat(MetaShift.getMsbPosition(Long.MAX_VALUE)).isEqualTo(63);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testNegativeException() {
-        assertThat(MetaShift.getMsbPosition(-34)).isEqualTo(64);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> MetaShift.getMsbPosition(-34));
     }
 
     @Test
@@ -25,9 +27,10 @@ public class MetaShiftTest {
         assertThat(f.config.feedback).isEqualTo(9L);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testBankSelectorOverrun() {
-        MetaShift.Func f = MetaShift.forSizeAndBank(4, 123);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> MetaShift.forSizeAndBank(4, 123));
     }
 
 //    @Test

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/DiscreteProbabilityBufferTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/DiscreteProbabilityBufferTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.core.stathelpers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DiscreteProbabilityBufferTest {
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/aliasmethod/AliasElementSamplerTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/aliasmethod/AliasElementSamplerTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.core.stathelpers.aliasmethod;
 
 import io.nosqlbench.virtdata.library.basics.core.stathelpers.AliasElementSampler;
 import io.nosqlbench.virtdata.library.basics.core.stathelpers.ElemProbD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/aliasmethod/AliasSamplerDoubleIntTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/core/stathelpers/aliasmethod/AliasSamplerDoubleIntTest.java
@@ -2,8 +2,8 @@ package io.nosqlbench.virtdata.library.basics.core.stathelpers.aliasmethod;
 
 import io.nosqlbench.virtdata.library.basics.core.stathelpers.AliasSamplerDoubleInt;
 import io.nosqlbench.virtdata.library.basics.core.stathelpers.EvProbD;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +60,7 @@ public class AliasSamplerDoubleIntTest {
     // Single threaded performance: 100000000 ops in 1366334133 nanos for 73188539.746449 ops/s
     // yes, that is >70M discrete probability samples per second, but hey, it's only 3 discrete probabilities in this test
     @Test
-    @Ignore
+    @Disabled
     public void testAliasMicroBenchSmallMany() {
         List<EvProbD> events = new ArrayList<>();
         events.add(new EvProbD(1,1D));

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/IntFlowTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/IntFlowTest.java
@@ -13,7 +13,7 @@ import io.nosqlbench.virtdata.library.basics.shared.unary_string.Prefix;
 import io.nosqlbench.virtdata.library.basics.shared.unary_string.StringFlow;
 import io.nosqlbench.virtdata.library.basics.shared.unary_string.Suffix;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.IntUnaryOperator;
 import java.util.function.LongFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/basicsmappers/ExprTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/basicsmappers/ExprTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.basicsmappers;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_double/ToStringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_double/ToStringTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.conversions.from_double;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.DoubleFunction;
 import java.util.function.DoubleUnaryOperator;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_long/ToByteBufferTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_long/ToByteBufferTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.conversions.from_long;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_long/ToStringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/conversions/from_long/ToStringTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.conversions.from_long;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/diagnostics/TypeOfTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/diagnostics/TypeOfTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.diagnostics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/distributions/CSVSamplerTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/distributions/CSVSamplerTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.distributions;
 
 import org.assertj.core.data.Percentage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_double/to_bigdecimal/ToBigDecimalTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_double/to_bigdecimal/ToBigDecimalTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_double.to_bigdecimal;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.MathContext;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_double/to_double/to_double/ClampTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_double/to_double/to_double/ClampTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_double.to_double.to_do
 
 import io.nosqlbench.virtdata.library.basics.shared.from_double.to_double.Clamp;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bigdecimal/ToBigDecimalTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bigdecimal/ToBigDecimalTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_bigdecimal;
 
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.MathContext;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/ByteBufferSizedHashedTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/ByteBufferSizedHashedTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_bytebuffer;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_int.HashRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.function.LongToIntFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/DigestToByteBufferTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/DigestToByteBufferTest.java
@@ -3,11 +3,12 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_bytebuffer;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class DigestToByteBufferTest {
 
@@ -39,11 +40,11 @@ public class DigestToByteBufferTest {
         System.out.println(Hex.encodeHexString(digest));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testInvalidName() {
         DigestToByteBuffer d1 = new DigestToByteBuffer("Whoops");
-        ByteBuffer digest = d1.apply(233423L);
-        assertThat(digest).isEqualTo(ByteBuffer.wrap(new byte[] {0x32}));
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> d1.apply(233423L));
     }
 
 }

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/HashedByteBufferExtractTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_bytebuffer/HashedByteBufferExtractTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_bytebuffer;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_charbuffer.CharBufferExtract;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.HashedLoremExtractToString;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListFunctionsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListFunctionsTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.function.LongFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListSizedHashedTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListSizedHashedTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.NumberNameToString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.function.LongFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/ListTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_int.HashRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.LongFunction;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/MapFunctionsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/MapFunctionsTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.function.LongFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/MapTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/MapTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/SetFunctionsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/SetFunctionsTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.function.*;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/SetTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_collection/SetTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.LongFunction;
 import java.util.function.LongToIntFunction;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashIntervalTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashIntervalTest.java
@@ -1,9 +1,10 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 
 import io.nosqlbench.nb.api.errors.BasicError;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class HashIntervalTest {
 
@@ -15,8 +16,9 @@ public class HashIntervalTest {
 
     }
 
-    @Test(expected = BasicError.class)
+    @Test
     public void testRangeError() {
-        HashInterval hi = new HashInterval(3L, 3L);
+        assertThatExceptionOfType(BasicError.class)
+                .isThrownBy(() -> new HashInterval(3L, 3L));
     }
 }

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashRangeScaledTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashRangeScaledTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 
 import org.assertj.core.data.Percentage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LongSummaryStatistics;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/InterpolateTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/InterpolateTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/SaveTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/SaveTest.java
@@ -3,7 +3,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.NumberNameToString;
 import io.nosqlbench.virtdata.library.basics.shared.stateful.Clear;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/ShuffleTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/ShuffleTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -59,7 +59,7 @@ public class ShuffleTest {
      * </pre>
      */
     @Test
-    @Ignore
+    @Disabled
     public void testWorstCaseThrough28Bits() {
         int min=1;
         int max=28;
@@ -115,7 +115,7 @@ public class ShuffleTest {
      * </pre>
      */
     @Test
-    @Ignore
+    @Disabled
     public void testBestCaseThrough31Bits() {
         int min=1;
         int max=31;
@@ -165,7 +165,7 @@ public class ShuffleTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void test97() {
         int max=97;
         Shuffle shuffle = new Shuffle(0,max);
@@ -184,7 +184,7 @@ public class ShuffleTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void test1000000() {
         int max=1000000;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/SwapTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/SwapTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_long;
 
 import io.nosqlbench.virtdata.library.basics.shared.stateful.Clear;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_object/CoinFuncTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_object/CoinFuncTest.java
@@ -4,8 +4,8 @@ import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.HashRange;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.Combinations;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.NumberNameToString;
 import io.nosqlbench.virtdata.library.basics.shared.functionadapters.ToLongFunction;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -27,7 +27,7 @@ public class CoinFuncTest {
     }
 
     // Uncomment this if you want to see the qualitative check
-    @Ignore
+    @Disabled
     @Test
     public void testResults() {
         CoinFunc f = new CoinFunc(0.1,

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_object/WeightedFuncsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_object/WeightedFuncsTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_object;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.FixedValues;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_other/NullsRatioTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_other/NullsRatioTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_other;
 
 import io.nosqlbench.virtdata.library.basics.core.threadstate.SharedState;
 import io.nosqlbench.virtdata.library.basics.shared.stateful.NullOrPass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/DirectoryLinesTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/DirectoryLinesTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/JoinTemplateTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/JoinTemplateTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.Mod;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/NumberNameToStringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/NumberNameToStringTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/TextImageExtractTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/TextImageExtractTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TextImageExtractTest {
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/ToBase64StringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/ToBase64StringTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/ToMD5ByteBufferTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_string/ToMD5ByteBufferTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_time_types/joda/TimezonesTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_time_types/joda/TimezonesTest.java
@@ -1,12 +1,14 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_time_types.joda;
 
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class TimezonesTest {
 
-    @Test(expected= RuntimeException.class)
+    @Test
     public void testInvalidId() {
-        DateTimeZone sdf = Timezones.forId("not gonna find it");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> Timezones.forId("not gonna find it"));
     }
 }

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_time_types/joda/ToMillisAtStartOfTimeframeTests.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_time_types/joda/ToMillisAtStartOfTimeframeTests.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.shared.from_long.to_time_types.jod
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_uuid/ToHashedUUIDTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_uuid/ToHashedUUIDTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_uuid;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_uuid/ToUUIDTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_uuid/ToUUIDTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_long.to_uuid;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_string/MatchFuncTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_string/MatchFuncTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_string/MatchRegexTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/from_string/MatchRegexTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.from_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/LoadThreadLocalTests.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/LoadThreadLocalTests.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.stateful;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/NullOrPassTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/NullOrPassTest.java
@@ -1,9 +1,10 @@
 package io.nosqlbench.virtdata.library.basics.shared.stateful;
 
 import io.nosqlbench.virtdata.library.basics.core.threadstate.SharedState;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class NullOrPassTest {
 
@@ -22,14 +23,16 @@ public class NullOrPassTest {
         NullOrPass g = new NullOrPass(0.0,"value");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testLowRatio() {
-        NullOrPass f = new NullOrPass(-0.00001d,"value");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> new NullOrPass(-0.00001d,"value"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testHighRatio() {
-        NullOrPass g = new NullOrPass(1.000001d,"value");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> new NullOrPass(1.000001d,"value"));
     }
 
 }

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/ShowTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/stateful/ShowTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.stateful;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.Save;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_int/IntHashTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_int/IntHashTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.unary_int;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/FieldExtractorTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/FieldExtractorTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.unary_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/ReplaceRegexTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/ReplaceRegexTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.shared.unary_string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/TemplateTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/shared/unary_string/TemplateTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.shared.unary_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.Template;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.*;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/libraryimpl/BasicDataMappersTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/libraryimpl/BasicDataMappersTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.basics.tests.libraryimpl;
 
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.Optional;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_collections/HashedRangeToLongListTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_collections/HashedRangeToLongListTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_collections;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_collection.HashedRangeToLongList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_double/HashedDoubleRangeTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_double/HashedDoubleRangeTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_double;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_double.HashedDoubleRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/HashRangeTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/HashRangeTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_long;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.HashRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/HashTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/HashTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_long;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/RangeTests.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/RangeTests.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.AddCycleRa
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.AddHashRange;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.CycleRange;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.HashRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/SignedHashTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_long/SignedHashTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_long;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.SignedHash;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/AlphaNumericStringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/AlphaNumericStringTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.AlphaNumericString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/CombinationsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/CombinationsTest.java
@@ -1,9 +1,10 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.Combinations;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class CombinationsTest {
 
@@ -69,11 +70,12 @@ public class CombinationsTest {
         assertThat(combinations.apply(31)).isEqualTo("D1");
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void testOverflow() {
         // (104^9 / 2^63) < 1.0
         // (104^10 / 2^63) > 1.0
-        Combinations combinations = new Combinations(
+        assertThatExceptionOfType(ArithmeticException.class)
+                .isThrownBy(() -> new Combinations(
                 "A-ZA-ZA-ZA-Z;"
                         + "A-ZA-ZA-ZA-Z;"
                         + "A-ZA-ZA-ZA-Z;"
@@ -84,9 +86,7 @@ public class CombinationsTest {
                         + "A-ZA-ZA-ZA-Z;"
                         + "A-ZA-ZA-ZA-Z;"
                         + "A-ZA-ZA-ZA-Z;"
-        );
-
-        combinations.apply(Long.MAX_VALUE);
+        ));
     }
 
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/HashedFileExtractToStringTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/HashedFileExtractToStringTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.HashedFileExtractToString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.IntSummaryStatistics;
 import java.util.function.LongUnaryOperator;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/WeightedStringsTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_string/WeightedStringsTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.basics.tests.long_string;
 
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.WeightedStrings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_timeuuid/TimeUUIDTests.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_timeuuid/TimeUUIDTests.java
@@ -6,7 +6,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_timeuuid/ToEpochTimeUUIDTest.java
+++ b/virtdata-lib-basics/src/test/java/io/nosqlbench/virtdata/library/basics/tests/long_timeuuid/ToEpochTimeUUIDTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.library.basics.core.DateTimeFormats;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_time_types.ToEpochTimeUUID;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/EnumeratedTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/EnumeratedTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.library.curves4.continuous;
 
 import io.nosqlbench.virtdata.library.curves4.continuous.long_double.Enumerated;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.stream.LongStream;

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/LevyTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/LevyTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.curves4.continuous;
 
 import io.nosqlbench.virtdata.library.curves4.continuous.long_double.Levy;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/RealDistributionsConcurrencyTests.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/RealDistributionsConcurrencyTests.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.library.curves4.continuous;
 
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/RealDistributionsValuesTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/continuous/RealDistributionsValuesTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.library.curves4.continuous.long_double.Normal;
 import io.nosqlbench.virtdata.library.curves4.continuous.long_double.Uniform;
 import org.apache.commons.math4.stat.descriptive.DescriptiveStatistics;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Formatter;
 import java.util.Locale;

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsBinomialSanity.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsBinomialSanity.java
@@ -3,8 +3,8 @@ package io.nosqlbench.virtdata.library.curves4.discrete;
 import io.nosqlbench.virtdata.library.curves4.discrete.common.DiscreteLongLongSampler;
 import io.nosqlbench.virtdata.library.curves4.discrete.common.IntegerDistributionICDSource;
 import org.apache.commons.statistics.distribution.BinomialDistribution;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -56,7 +56,7 @@ public class IntegerDistributionsBinomialSanity {
 
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void showBinomialICDF() {
         DiscreteLongLongSampler b85 = new DiscreteLongLongSampler(new IntegerDistributionICDSource(

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsConcurrencyTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsConcurrencyTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
 import org.apache.commons.statistics.distribution.BinomialDistribution;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsValuesTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/IntegerDistributionsValuesTest.java
@@ -4,8 +4,8 @@ import io.nosqlbench.virtdata.library.curves4.continuous.long_double.Uniform;
 import io.nosqlbench.virtdata.library.curves4.discrete.long_long.Zipf;
 import org.apache.commons.math4.stat.descriptive.DescriptiveStatistics;
 import org.assertj.core.data.Offset;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Formatter;
 import java.util.Locale;
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegerDistributionsValuesTest {
 
-    @Ignore
+    @Disabled
     @Test
     public void testComputedZipf() {
         RunData runData = iterateMapperLong(new Zipf(10000,2.0), 10000);

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/common/ThreadSafeHashTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/common/ThreadSafeHashTest.java
@@ -1,6 +1,6 @@
 package io.nosqlbench.virtdata.library.curves4.discrete.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/long_long/ZipfTest.java
+++ b/virtdata-lib-curves4/src/test/java/io/nosqlbench/virtdata/library/curves4/discrete/long_long/ZipfTest.java
@@ -1,12 +1,12 @@
 package io.nosqlbench.virtdata.library.curves4.discrete.long_long;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ZipfTest {
 
     @Test
-    @Ignore
+    @Disabled
     public void testZipfMatrix() {
 
         for (int i = 0; i < 20; i++) {

--- a/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/core/VirtDataDocsIntegratedTest.java
+++ b/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/core/VirtDataDocsIntegratedTest.java
@@ -2,7 +2,7 @@ package io.nosqlbench.virtdata.core;
 
 import io.nosqlbench.virtdata.core.bindings.VirtDataDocs;
 import io.nosqlbench.virtdata.api.processors.DocFuncData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/apps/docsapp/FDocFuncsTest.java
+++ b/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/apps/docsapp/FDocFuncsTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.userlibs.apps.docsapp.fdocs.ExampleDocFunc1;
 import io.nosqlbench.virtdata.userlibs.apps.docsapp.fdocs.ExampleDocFunc2;
 import io.nosqlbench.virtdata.userlibs.apps.docsapp.fdocs.FDocFunc;
 import io.nosqlbench.virtdata.userlibs.apps.docsapp.fdocs.FDocFuncs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FDocFuncsTest {
 

--- a/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/streams/fillers/ChunkedByteBufferTest.java
+++ b/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/streams/fillers/ChunkedByteBufferTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.userlibs.streams.fillers;
 
 import io.nosqlbench.virtdata.userlibs.streams.ByteBufferStreams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 

--- a/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/streams/pojos/ByteBufferFillableTest.java
+++ b/virtdata-userlibs/src/test/java/io/nosqlbench/virtdata/userlibs/streams/pojos/ByteBufferFillableTest.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.virtdata.userlibs.streams.pojos;
 
 import io.nosqlbench.virtdata.userlibs.streams.fillers.ByteBufferSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedAliasMethodTests.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedAliasMethodTests.java
@@ -3,7 +3,7 @@ package io.virtdata;
 import io.nosqlbench.virtdata.library.basics.shared.distributions.DelimFrequencySampler;
 import io.nosqlbench.virtdata.library.basics.shared.distributions.WeightedStringsFromCSV;
 import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVFrequencySampler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedBindingsTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedBindingsTest.java
@@ -18,7 +18,7 @@ package io.virtdata;
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedComposerLibraryTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedComposerLibraryTest.java
@@ -20,28 +20,25 @@ import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
 import io.nosqlbench.virtdata.core.bindings.ResolverDiagnostics;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class IntegratedComposerLibraryTest {
 
     // The deprecated functions are not being included in the next release, so this test's purpose has been
     // reversed.
-    @Test(expected=RuntimeException.class)
+    @Test
     public void testArgumentMatchingViaMainLib() {
         BindingsTemplate bt = new BindingsTemplate();
         bt.addFieldBinding("param","RandomLineToString('data/variable_words.txt')");
-        Bindings bindings = bt.resolveBindings();
-        Object[] all = bindings.getAll(5);
-        assertThat(all).isNotNull();
-        assertThat(all.length).isEqualTo(1);
-        Object o = all[0];
-        assertThat(o.getClass()).isEqualTo(String.class);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> bt.resolveBindings());
     }
 
     @Test
@@ -83,7 +80,7 @@ public class IntegratedComposerLibraryTest {
 
     // TODO: Fix this test
     @Test
-    @Ignore
+    @Disabled
     public void testTypeCoercionWhenNeeded() {
         BindingsTemplate bt = new BindingsTemplate();
         bt.addFieldBinding("mod_to_string", "compose Mod(3) ; Suffix('0000000000') -> String");
@@ -98,7 +95,7 @@ public class IntegratedComposerLibraryTest {
 
     // TODO: Fix this test
     @Test
-    @Ignore
+    @Disabled
     public void testBasicRange() {
         BindingsTemplate bt = new BindingsTemplate();
         bt.addFieldBinding("phone","HashRange(1000000000, 9999999999)");

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedComposerLogicTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedComposerLogicTest.java
@@ -6,7 +6,7 @@ import io.nosqlbench.virtdata.library.basics.shared.from_long.to_long.Identity;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.NumberNameToString;
 import io.nosqlbench.virtdata.library.basics.shared.from_long.to_string.Template;
 import org.apache.commons.lang3.ClassUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -14,6 +14,7 @@ import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class IntegratedComposerLogicTest {
 
@@ -142,9 +143,10 @@ public class IntegratedComposerLogicTest {
 
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testVirtDataTypeVarianceError() {
-        DataMapper mapper = VirtData.getMapper("Uniform(0.0D,1.0D) -> java.lang.String", long.class);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> VirtData.getMapper("Uniform(0.0D,1.0D) -> java.lang.String", long.class));
     }
 
     @Test

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedCurvesTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedCurvesTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.assertj.core.data.Offset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Formatter;
 import java.util.Locale;

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedRealerTests.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedRealerTests.java
@@ -2,7 +2,7 @@ package io.virtdata;
 
 import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedStringCompositorTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedStringCompositorTest.java
@@ -3,8 +3,8 @@ package io.virtdata;
 import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
 import io.nosqlbench.virtdata.core.templates.StringCompositor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
@@ -15,7 +15,7 @@ public class IntegratedStringCompositorTest {
     private static BindingsTemplate template;
     private static Bindings bindings;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupTemplate() {
         BindingsTemplate bindingsTemplate = new BindingsTemplate();
         bindingsTemplate.addFieldBinding("ident","Identity()");

--- a/virtdata-userlibs/src/test/java/io/virtdata/IntegratedTemporalExamplesTest.java
+++ b/virtdata-userlibs/src/test/java/io/virtdata/IntegratedTemporalExamplesTest.java
@@ -4,7 +4,7 @@ import io.nosqlbench.virtdata.core.bindings.DataMapper;
 import io.nosqlbench.virtdata.core.bindings.VirtData;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.UUID;


### PR DESCRIPTION
mostly trivial changes by using the junit5 apis instead.
except for expected exceptions where we use `assertThatExceptionOfType` on a narrower scope.

see inline comments for things to note/review more carefully.

tested locally with:
```
mvn -T 0.5C clean package
```