### PR TITLE
upgrade antlr4-maven-plugin to v4.9.2 avoid threadsafety warnings

### DIFF
--- a/driver-cql-shaded/pom.xml
+++ b/driver-cql-shaded/pom.xml
@@ -142,7 +142,6 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.8</version>
                 <configuration>
                     <sourceDirectory>src/main/grammars/cql3
                     </sourceDirectory>

--- a/driver-cqld3-shaded/pom.xml
+++ b/driver-cqld3-shaded/pom.xml
@@ -138,7 +138,6 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.8</version>
                 <configuration>
                     <sourceDirectory>src/main/grammars/cql3
                     </sourceDirectory>

--- a/driver-dsegraph-shaded/pom.xml
+++ b/driver-dsegraph-shaded/pom.xml
@@ -174,7 +174,6 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>4.8</version>
         <configuration>
           <sourceDirectory>src/main/grammars/cql3
           </sourceDirectory>

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -559,7 +559,7 @@
         <plugin>
           <groupId>org.antlr</groupId>
           <artifactId>antlr4-maven-plugin</artifactId>
-          <version>4.8</version>
+          <version>4.9.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
when running a maven build with the `-T,--threads` flag for faster builds the `antlr4-maven-plugin` causes a threadsafety warning being output.
upgrading the plugin to the latest version resolves that.

i had no easy way to test if antlr stuff still works correctly (but the build succeeds).

before:
```
# in ~/code/nosqlbench on git:main ● [10:19:47]
→ mvn -T 0.5C clean package >build.txt 2>&1; echo $?; grep -C2 threadSafe build.txt
0
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
--
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in virtdata-lang:
[WARNING] org.antlr:antlr4-maven-plugin:4.8
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
[INFO] 
--
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
--
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in driver-dsegraph-shaded:
[WARNING] org.antlr:antlr4-maven-plugin:4.8
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
[INFO] 
--
[INFO] 
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * as @threadSafe to support parallel building.                  *
[INFO] --- maven-jar-plugin:3.1.1:jar (default-jar) @ driver-http ---
[WARNING] * While this /may/ work fine, please look for plugin updates    *
--
[WARNING] *****************************************************************
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] The following plugins are not marked @threadSafe in driver-cql-shaded:
[WARNING] * question, not against maven-core                              *
[WARNING] org.antlr:antlr4-maven-plugin:4.8
[WARNING] *****************************************************************
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] The following plugins are not marked @threadSafe in driver-cqld3-shaded:
[WARNING] *****************************************************************
[WARNING] org.antlr:antlr4-maven-plugin:4.8
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```

after:
```
# in ~/code/nosqlbench on git:avoid-threadsafey-warnings ✖︎ [10:25:15]
→ mvn -T 0.5C clean package >build.txt 2>&1; echo $?; grep -C2 threadSafe build.txt
0
```