### PR TITLE
unify antlr4 version

### DIFF
--- a/driver-cql-shaded/pom.xml
+++ b/driver-cql-shaded/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.2</version>
         </dependency>
 
         <dependency>

--- a/driver-cqld3-shaded/pom.xml
+++ b/driver-cqld3-shaded/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.2</version>
         </dependency>
 
         <dependency>

--- a/driver-dsegraph-shaded/pom.xml
+++ b/driver-dsegraph-shaded/pom.xml
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>4.9.2</version>
     </dependency>
 
     <!--        <dependency>-->

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -13,6 +13,7 @@
 
     <!-- properties for package versions -->
     <ascii.data.version>1.2.0</ascii.data.version>
+    <antlr4.version>4.9.2</antlr4.version>
     <commons.codec.version>1.14</commons.codec.version>
     <commons.compress.version>1.20</commons.compress.version>
     <commons.csv.version>1.8</commons.csv.version>
@@ -270,7 +271,7 @@
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
-        <version>4.9.2</version>
+        <version>${antlr4.version}</version>
       </dependency>
 
       <dependency>
@@ -547,7 +548,7 @@
         <plugin>
           <groupId>org.antlr</groupId>
           <artifactId>antlr4-maven-plugin</artifactId>
-          <version>4.9.2</version>
+          <version>${antlr4.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/virtdata-lang/pom.xml
+++ b/virtdata-lang/pom.xml
@@ -19,7 +19,6 @@
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
sorry for missing this earlier in https://github.com/nosqlbench/nosqlbench/pull/335

we further unify this by only defining the antlr4 version once.

also i noticed that the tests on main are failing, which is fixed by the 2nd commit.