### PR TITLE
Adds support in NBIO for S3 URI's

### DIFF
--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -371,6 +371,13 @@
       <scope>test</scope>
     </dependency>
 
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>3.3.3</version>
+          <scope>test</scope>
+      </dependency>
+
   </dependencies>
 
   <build>

--- a/nb-api/pom.xml
+++ b/nb-api/pom.xml
@@ -62,6 +62,12 @@
       <artifactId>oshi-core</artifactId>
     </dependency>
 
+      <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-s3</artifactId>
+          <version>1.12.12</version>
+      </dependency>
+
       <!-- perf testing -->
 
     <dependency>

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/ResolverForS3.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/ResolverForS3.java
@@ -1,0 +1,77 @@
+package io.nosqlbench.nb.api.content;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+public class ResolverForS3 implements ContentResolver {
+    public final static ResolverForS3 INSTANCE = new ResolverForS3(new S3Client());
+    private final static Logger logger = LogManager.getLogger(ResolverForS3.class);
+    private final S3Access s3Access;
+
+    public ResolverForS3(S3Access s3Access) {
+        this.s3Access = s3Access;
+    }
+
+    @Override
+    public List<Content<?>> resolve(URI uri) {
+        URIContent s3URIContent = resolveURI(uri);
+        if (s3URIContent != null) {
+            return List.of(s3URIContent);
+        }
+        return List.of();
+    }
+
+    public URIContent resolveURI(URI uri) {
+        if (uri == null || uri.getScheme() == null) {
+            return null;
+        }
+        if (uri.getScheme().equals("s3")) {
+            try {
+                AmazonS3URI s3URI = new AmazonS3URI(uri);
+                String bucket = s3URI.getBucket();
+                String key = s3URI.getKey();
+                InputStream in = s3Access.openS3Object(bucket, key);
+                return new URIContent(uri, in);
+            } catch (AmazonServiceException e) {
+                logger.warn("Failed to access S3 object at '" + uri + "': " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Path> resolveDirectory(URI uri) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() { return getClass().getSimpleName(); }
+
+    public static class S3Client implements S3Access {
+        public AmazonS3 s3InternalClient;
+
+        @Override
+        public InputStream openS3Object(String bucket, String key) {
+            S3Object s3Object = getS3InternalClient().getObject(bucket, key);
+            return s3Object.getObjectContent();
+        }
+
+        public synchronized AmazonS3 getS3InternalClient() {
+            if (s3InternalClient == null) {
+                s3InternalClient = AmazonS3ClientBuilder.defaultClient();
+            }
+            return s3InternalClient;
+        }
+    }
+}

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/S3Access.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/S3Access.java
@@ -1,0 +1,7 @@
+package io.nosqlbench.nb.api.content;
+
+import java.io.InputStream;
+
+public interface S3Access {
+    InputStream openS3Object(String bucket, String key);
+}

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/StreamContent.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/StreamContent.java
@@ -1,0 +1,53 @@
+package io.nosqlbench.nb.api.content;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * StreamContent is meant for short-lived use as an efficient way to
+ * find a read URL content. If a caller has already acquired an
+ * input stream, it can be passed to the stream content holder
+ * to avoid double fetch or other unintuitive and inefficient
+ * behavior.
+ *
+ * Subclasses must implement getURI()
+ */
+public abstract class StreamContent<T> implements Content<T> {
+    private final T location;
+    private final InputStream inputStream;
+
+    public StreamContent(T location, InputStream inputStream) {
+        this.location = location;
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public T getLocation() {
+        return location;
+    }
+
+    @Override
+    public CharBuffer getCharBuffer() {
+        InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+        Stream<String> lines = bufferedReader.lines();
+        String buffdata = lines.map(l -> l+"\n").collect(Collectors.joining());
+        return CharBuffer.wrap(buffdata);
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    @Override
+    public Path asPath() {
+        return null;
+    }
+}

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/URIContent.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/URIContent.java
@@ -1,0 +1,35 @@
+package io.nosqlbench.nb.api.content;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Objects;
+
+public class URIContent extends StreamContent<URI> {
+    private final URI uri;
+
+    public URIContent(URI uri, InputStream inputStream) {
+        super(uri, inputStream);
+        this.uri = uri;
+    }
+
+    @Override
+    public URI getURI() {
+        return uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        URIContent that = (URIContent) o;
+        return Objects.equals(uri, that.uri);}
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri);
+    }
+
+    public String toString() {
+        return "URIContent{" + getURI().toString() + "}";
+    }
+}

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/URIResolver.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/URIResolver.java
@@ -1,13 +1,11 @@
 package io.nosqlbench.nb.api.content;
 
 import io.nosqlbench.nb.api.errors.BasicError;
-import org.apache.commons.math3.FieldElement;
 
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This is a stateful search object for resources like Paths or URLs.
@@ -19,6 +17,7 @@ public class URIResolver implements ContentResolver {
     private List<ContentResolver> loaders = new ArrayList<>();
 
     private static List<ContentResolver> EVERYWHERE = List.of(
+        ResolverForS3.INSTANCE,
         ResolverForURL.INSTANCE,
         ResolverForFilesystem.INSTANCE,
         ResolverForClasspath.INSTANCE
@@ -55,6 +54,7 @@ public class URIResolver implements ContentResolver {
      * @return this URISearch
      */
     public URIResolver inURLs() {
+        loaders.add(ResolverForS3.INSTANCE);
         loaders.add(ResolverForURL.INSTANCE);
         return this;
     }

--- a/nb-api/src/main/java/io/nosqlbench/nb/api/content/URLContent.java
+++ b/nb-api/src/main/java/io/nosqlbench/nb/api/content/URLContent.java
@@ -1,40 +1,17 @@
 package io.nosqlbench.nb.api.content;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-/**
- * StreamContent is meant for short-lived use as an efficient way to
- * find a read URL content. If a caller has already acquired an
- * input stream, it can be passed to the stream content holder
- * to avoid double fetch or other unintuitive and inefficient
- * behavior.
- */
-public class URLContent implements Content<URL> {
-
+public class URLContent extends StreamContent<URL> {
     private final URL url;
-    private CharBuffer buffer;
-    private InputStream inputStream;
 
     public URLContent(URL url, InputStream inputStream) {
+        super(url, inputStream);
         this.url = url;
-        this.inputStream = inputStream;
-    }
-
-    @Override
-    public URL getLocation() {
-        return url;
     }
 
     @Override
@@ -56,24 +33,6 @@ public class URLContent implements Content<URL> {
     @Override
     public int hashCode() {
         return Objects.hash(url);
-    }
-
-    @Override
-    public CharBuffer getCharBuffer() {
-        if (buffer==null) {
-            InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
-            Stream<String> lines = bufferedReader.lines();
-            String buffdata = lines.map(l -> l+"\n").collect(Collectors.joining());
-            return CharBuffer.wrap(buffdata);
-        }
-
-        return buffer;
-    }
-
-    @Override
-    public Path asPath() {
-        return null;
     }
 
     public String toString() {


### PR DESCRIPTION
UX notes:

- Credentials and region must be set either in environment variables or an ~/.aws/... file ([doc](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html)). Wasn't sure where to document this.
- Warning log is emitted unless there are both .yml and .yaml extension files available in the given path. I don't know how to avoid this due to the way ResolverForS3 is called: it doesn't have a global view of all paths requested by the CLI, so it can't determine if "at least one file was found". For example, only the .yaml extension file exists:
    ```
    ./nb run type=stdout workload=s3://my-bucket/my-prefix/s3-postgres-basic tags=phase:schema
       6156 WARN  [scenarios:001] ResolverForS3 Failed to access S3 object at 's3://my-bucket/my-prefix/s3-postgres-basic.yml': The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: ZYQV5ZCC9Z36RYG4; S3 Extended Request ID: 7TQ4fcG1RJfBPlwz6FAgnugc6bR3o6hDTAAGlKa91VHh39pI60xD6AQi+X1AyP9U5I7f24Jw4xQ=; Proxy: null)
    CREATE TABLE IF NOT EXISTS "account2" (
      uuid UUID PRIMARY KEY,
      amount INTEGER,
      amount_unit VARCHAR(64),
      updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
      created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
      filler TEXT
    );
    CREATE INDEX IF NOT EXISTS amount_idx on "account2" (amount);
    CREATE INDEX IF NOT EXISTS updated_at_idx on "account2" (updated_at);
    ```

New dependencies added:

- com.amazonaws:aws-java-sdk-s3:1.12.12
- org.mockito:mockito-core:3.3.3

Implementation notes:

- Refactored common parts of existing URLContent and new URIContent to parent class StreamContent