### PR TITLE
Refactor error format for error handling in JDBCActivity

### DIFF
--- a/driver-cockroachdb/src/main/resources/activities/cockroachdb-basic.yaml
+++ b/driver-cockroachdb/src/main/resources/activities/cockroachdb-basic.yaml
@@ -4,12 +4,15 @@ description: An example of a basic cockroach insert
 
 scenarios:
   default:
-    - run driver=cockroachdb tags==phase:main threads==auto cycles===<<main-cycles:1000000>>
+    - run driver=cockroachdb tags==phase:main threads=auto cycles===<<main-cycles:1000000>>
+      serverName=localhost connectionpool=hikari
+      errors=SQLTransient.*:warn,count,retry;.*0800.*:warn,count,retry;.*40001:count,retry;stop
   rampup:
-    - run driver=cockroachdb tags==phase:rampup threads==auto cycles===<<rampup-cycles:1000000>>
+    - run driver=cockroachdb tags==phase:rampup threads=auto cycles===<<rampup-cycles:1000000>>
+      serverName=localhost connectionpool=hikari
+      errors=SQLTransient.*:warn,count,retry;.*0800.*:warn,count,retry;.*40001:count,retry;stop
   schema:
-    - run driver=cockroachdb tags==phase:schema threads==1 cycles===2
-    #- run driver=stdout tags==phase:schema threads==1 cycles===UNDEF
+    - run driver=cockroachdb tags==phase:schema threads===1 serverName=localhost
 
 bindings:
   seq_key: Mod(<<keyCount:1000000>>L); ToInt()
@@ -39,7 +42,10 @@ blocks:
       phase: rampup
     params:
     statements:
-      - rampup-insert: insert into <<database:bank>>.<<table:banktransaction>> ( code, amount ) values ( '{seq_key}', {seq_value} );
+      - rampup-insert: |
+          INSERT INTO "<<database:bank>>"."<<table:banktransaction>>"
+          (code, amount) VALUES ('{seq_key}', {seq_value})
+          ON CONFLICT (code) DO NOTHING;
         params:
         tags:
           name: rampup-insert
@@ -51,7 +57,8 @@ blocks:
       ratio: <<read_ratio:1>>
     statements:
       - main-find: |
-          SELECT code, amount FROM <<database:bank>>.<<table:banktransaction>> WHERE code = '{rw_key}' AND amount = {rw_value};
+          SELECT code, amount FROM "<<database:bank>>"."<<table:banktransaction>>"
+          WHERE code = '{rw_key}' AND amount = {rw_value};
         params:
         tags:
           name: main-find
@@ -63,7 +70,7 @@ blocks:
       ratio: <<write_ratio:1>>
     statements:
       - main-insert: |
-          UPDATE <<database:bank>>.<<table:banktransaction>> SET amount = {seq_value} WHERE code = '{seq_key}';
+          UPDATE "<<database:bank>>"."<<table:banktransaction>>" SET amount = {seq_value} WHERE code = '{seq_key}';
         params:
         tags:
           name: main-insert

--- a/driver-cockroachdb/src/main/resources/activities/postgres-basic.yaml
+++ b/driver-cockroachdb/src/main/resources/activities/postgres-basic.yaml
@@ -1,24 +1,27 @@
 # java -jar nb.jar run driver=cockroachdb workload=postgres-basic tags=phase:rampup cycles=10 \
 #   serverName=localhost databaseName=bank
-# java -jar nb.jar run driver=cockroachdb workload=postgres-basic tags=phase:main cycles=10 serverName=localhost 
+# java -jar nb.jar run driver=cockroachdb workload=postgres-basic tags=phase:main cycles=10 serverName=localhost
 description: An example of a basic postgres bank transaction workload
 
 scenarios:
   default:
-    - run driver===cockroachdb tags===phase:main threads==auto cycles=10000000
-      serverName=localhost portNumber=5432 databaseName=<<database:bank>> user=postgres
-      password=postgres
-  rampup:
-    - run driver===cockroachdb tags===phase:rampup threads==auto cycles=<<accounts:1000000>>
-      serverName=localhost portNumber=5432 databaseName=<<database:bank>> user=postgres
-      password=postgres connectionpool=hikari filler-binding="AlphaNumericString(10)"
-  rampup-large:
-    - run driver===cockroachdb tags===phase:rampup threads==auto cycles=<<accounts:1000000>>
+    - run driver===cockroachdb tags===phase:main threads=auto cycles=10000000
       serverName=localhost portNumber=5432 databaseName=<<database:bank>> user=postgres
       password=postgres connectionpool=hikari
+      errors=SQLTransient.*:warn,count,retry;.*0800.*:warn,count,retry;stop
+  rampup:
+    - run driver===cockroachdb tags===phase:rampup threads=auto cycles=<<accounts:1000000>>
+      serverName=localhost portNumber=5432 databaseName=<<database:bank>> user=postgres
+      password=postgres connectionpool=hikari filler-binding="AlphaNumericString(10)"
+      errors=SQLTransient.*:warn,count,retry;.*0800.*:warn,count,retry;stop
+  rampup-large:
+    - run driver===cockroachdb tags===phase:rampup threads=auto cycles=<<accounts:1000000>>
+      serverName=localhost portNumber=5432 databaseName=<<database:bank>> user=postgres
+      password=postgres connectionpool=hikari
+      errors=SQLTransient.*:warn,count,retry;.*0800.*:warn,count,retry;stop
   schema:
     - run driver===cockroachdb tags===phase:schema threads===1 serverName=localhost portNumber=5432
-      databaseName=bank user=postgres password=postgres connectionpool=hikari
+      databaseName=bank user=postgres password=postgres
 
 bindings:
   seq_uuid: Mod(<<accounts:1000000>>L); ToHashedUUID()
@@ -55,7 +58,7 @@ blocks:
     params:
     statements:
       - rampup-insert: |
-          INSERT INTO "<<table:account>>" (uuid, amount, amount_unit, updated_at, created_at, filler) 
+          INSERT INTO "<<table:account>>" (uuid, amount, amount_unit, updated_at, created_at, filler)
           VALUES ('{seq_uuid}', {rand_amount}, 'us_cents', '{timestamp}', '{timestamp}', '{filler}')
           ON CONFLICT DO NOTHING;
         params:

--- a/driver-cockroachdb/src/main/resources/cockroachdb.md
+++ b/driver-cockroachdb/src/main/resources/cockroachdb.md
@@ -21,6 +21,30 @@ section for detailed parameter documentation.
     * *hikari* -
       use [HikariCP](https://github.com/brettwooldridge/HikariCP)
 * **maxtries** (optional) - number of times to retry retry-able errors; Default *3*.
-* **errors** (optional) - expression which specifies how to handle SQL state error codes.
-  Expression syntax and behavior is explained in the `error-handlers` topic. Default
-  *stop*, in other words exit on any error.
+* **minretrydelayms** (optional) - minimum time in ms to wait before retry with exponential backoff; Default *200*.
+* **errors** (optional) - see `error-handlers` topic for details (`./nb help error-handlers`). Default *stop*.
+
+#### errors parameter
+
+This parameter expects an expression which specifies how to handle exceptions by class name
+and SQL state code. Error names are formatted as `<exception-name>_<sql-state>`.
+
+For example, a *org.postgresql.util.PSQLException* with *SQLState=80001* will be formatted `PSQLException_80001`.
+To continue on such an error, use `errors=PQLException_80001:warn,count;stop`. To retry any
+*java.sql.SQLTransientException* or any *SQLState=80001* and otherwise stop, use
+`errors=SQLTransientException.*:warn,count,retry;.*80001:warn,count,retry;stop`.
+
+See scenario implementations in workloads `cockroachdb-basic` and `postgres-basic` for reasonable defaults
+of the errors parameter. This is a reasonable default error handler chain:
+
+1. `SQLTransient.*:warn,count,retry` - log, emit metric, and retry on transient errors
+([java.sql doc](https://docs.oracle.com/javase/8/docs/api/java/sql/SQLTransientException.html))
+2. `.*0800.*:warn,count,retry` - log, emit metric, and retry on "connection exception" class of postgresql driver
+SQLState codes ([postgresql java doc](https://www.postgresql.org/docs/9.4/errcodes-appendix.html))
+3. `.*40001:count,retry` - emit metric and retry on "serialization error" SQLState code of postgresql driver
+([postgresql java doc](https://www.postgresql.org/docs/9.4/errcodes-appendix.html)).
+These are common with CockroachDB
+([doc](https://www.cockroachlabs.com/docs/stable/error-handling-and-troubleshooting.html#transaction-retry-errors)).
+4. `stop` - stop the activity for any other error or if max retries are exceeded
+
+

--- a/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
+++ b/driver-cockroachdb/src/test/java/io/nosqlbench/activitytype/cockroachdb/CockroachActivityTest.java
@@ -7,9 +7,11 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URL;
 import java.sql.SQLException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CockroachActivityTest {
     @Test
@@ -19,12 +21,16 @@ public class CockroachActivityTest {
 
         // When the Throwable is a SQLException, the error name should be getSQLState()
         Throwable sqlException = new SQLException("my test exception", "my-test-sql-state");
-        assertEquals("my-test-sql-state", activity.errorNameMapper(sqlException));
+        assertEquals("SQLException_my-test-sql-state", activity.errorNameMapper(sqlException));
 
         // See PSQLState to string code mapping at the Github source code website
         // https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
         Throwable psqlException = new PSQLException("retry transaction", PSQLState.CONNECTION_FAILURE);
-        assertEquals("08006", activity.errorNameMapper(psqlException));
+        assertEquals("PSQLException_08006", activity.errorNameMapper(psqlException));
+
+        // When SQLState is null or empty, suffix shouldn't be underscore
+        Throwable nullSQLState = new PSQLException("my test runtime exception", null);
+        assertEquals("PSQLException", activity.errorNameMapper(nullSQLState));
 
         // When Throwable is not a SQLException, the error name should be the class name
         Throwable runtimeException = new SocketTimeoutException("my test runtime exception");


### PR DESCRIPTION
Add examples for default error handler specs for cockroabdb-basic and postgres-basic workloads.
Fixes a retry bug in JDBCAction where previously max retries wouldn't throw an error.