### PR TITLE
fixing the stargate key-value scenarios

### DIFF
--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-keyvalue.yaml
@@ -11,7 +11,7 @@ description: |
 scenarios:
   default:
     schema: run driver=http tags==phase:schema threads==1 cycles==UNDEF
-    rumpup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
     main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-keyvalue.yaml
@@ -1,4 +1,4 @@
-# nb -v run driver=http yaml=http-docsapi-keyvalue tags=phase:schema host=my_stargate_host stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+# nb -v run driver=http yaml=http-docsapi-keyvalue tags=phase:schema stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
 
 description: |
   This workload emulates a key-value data model and access patterns.
@@ -10,9 +10,9 @@ description: |
 
 scenarios:
   default:
-    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
-    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=http tags==phase:schema threads==1 cycles==UNDEF
+    rumpup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
   # Examples
@@ -23,10 +23,10 @@ bindings:
   # http request id
   request_id: ToHashedUUID(); ToString();
 
-  seq_key: Mod(<<keycount:1000000000>>); ToString() -> String
-  seq_value: Hash(); Mod(<<valuecount:1000000000>>); ToString() -> String
-  rw_key: <<keydist:Uniform(0,1000000000)->int>>; ToString() -> String
-  rw_value: Hash(); <<valdist:Uniform(0,1000000000)->int>>; ToString() -> String
+  seq_key: Mod(<<keycount:10000000>>); ToString() -> String
+  seq_value: Hash(); Mod(<<valuecount:10000000>>); ToString() -> String
+  rw_key: <<keydist:Uniform(0,<<keycount:10000000>>)->int>>; ToString() -> String
+  rw_value: Hash(); <<valdist:Uniform(0,<<keycount:10000000>>)->int>>; ToString() -> String
 
 blocks:
   - tags:
@@ -44,6 +44,13 @@ blocks:
           }
         tags:
           name: create-keyspace
+      - delete-docs-collection : DELETE <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_keyvalue>>/collections/<<table:docs_collection>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        tags:
+          name: delete-table
+        ok-status: "[2-4][0-9][0-9]"
       - create-docs-collection : POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_keyvalue>>/collections
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -77,7 +84,7 @@ blocks:
       phase: main
       type: read
     params:
-      ratio: <<read_ratio:1>>
+      ratio: <<read_ratio:5>>
     statements:
       - main-select: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_keyvalue>>/collections/<<table:docs_collection>>/{rw_key}
         Accept: "application/json"
@@ -85,13 +92,14 @@ blocks:
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
         tags:
           name: main-select
+        ok-status: "[2-4][0-9][0-9]"
 
   - name: main-write
     tags:
       phase: main
       type: write
     params:
-      ratio: <<write_ratio:9>>
+      ratio: <<write_ratio:5>>
     statements:
       - main-write: PUT <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_keyvalue>>/collections/<<table:docs_collection>>/{rw_key}
         Accept: "application/json"


### PR DESCRIPTION
Fixing of the Stargate Docs API key-value scenario. Multiple things are done here:

1. `rw_key` is set to uniformly go up to `keycount` only. This means that we read up to the elements inserted with `seq_key`.
2. However, since ramp-up cycles were in default scenario lower that keycount, I actually made those two equal, so default scenario writes 10M in he rampup and then read those 10M in the main.
3. added delete table in schema, to clear-up any possible documents before the test (if exists)
4. accept 404 on read, because you could say `keycount=100 rumpup-cycles=80`. This would mean write 80 docs, but target 100 in reads, meaning 20% misses; so we can design tests to have some percentage of the misses as well
5. made read and write rating to 5 each, as in the original [key-value cql scenario](https://github.com/nosqlbench/nosqlbench/blob/main/driver-cql-shaded/src/main/resources/activities/baselines/cql-keyvalue.yaml)
6. named steps in default scenario for easier metrics correlation

@EricBorczuk Any chance you can fix other Stargate key-value activities following these changes?
@dougwettlaufer FYI