### PR TITLE
Fix a few keyvalue test cases

### DIFF
--- a/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
@@ -7,9 +7,9 @@ description: |
 
 scenarios:
   default:
-    - run driver=cql tags==phase:schema threads==1 cycles==UNDEF
-    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
   # Examples
@@ -20,9 +20,9 @@ bindings:
   # http request id
   request_id: ToHashedUUID(); ToString();
 
-  seq_key: Mod(<<keycount:1000000000>>); ToString() -> String
+  seq_key: Mod(<<keycount:10000000>>); ToString() -> String
   seq_value: Hash(); Mod(<<valuecount:1000000000>>); ToString() -> String
-  rw_key: <<keydist:Uniform(0,1000000000)->int>>; ToString() -> String
+  rw_key: <<keydist:Uniform(0,10000000)->int>>; ToString() -> String
   rw_value: Hash(); <<valdist:Uniform(0,1000000000)->int>>; ToString() -> String
 
 blocks:
@@ -42,6 +42,14 @@ blocks:
           }
         tags:
           name: create-keyspace
+      - drop-table: DELETE <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables/<<table:keyvalue>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: drop-table
+        ok-status: "[2-4][0-9][0-9]"
       - create-table: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces/<<keyspace:baselines>>/tables
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -120,7 +128,7 @@ blocks:
       phase: main
       type: read
     params:
-      ratio: 5
+      ratio: <<read_ratio:5>>
     statements:
       - main-select: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/keyspaces/<<keyspace:baselines>>/<<table:keyvalue>>/{rw_key}
         Accept: "application/json"
@@ -129,12 +137,13 @@ blocks:
         Content-Type: "application/json"
         tags:
           name: main-select
+        ok-status: "[2-4][0-9][0-9]"
   - name: main-write
     tags:
       phase: main
       type: write
     params:
-      ratio: 5
+      ratio: <<write_ratio:5>>
     statements:
       - main-write: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/keyspaces/<<keyspace:baselines>>/<<table:keyvalue>>
         Accept: "application/json"

--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
@@ -8,9 +8,9 @@ description: |
 
 scenarios:
   default:
-    - run driver=cql tags==phase:schema threads==1 cycles==UNDEF
-    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
   # Examples
@@ -21,9 +21,9 @@ bindings:
   # http request id
   request_id: ToHashedUUID(); ToString();
 
-  seq_key: Mod(<<keycount:1000000000>>); ToString() -> String
+  seq_key: Mod(<<keycount:10000000>>); ToString() -> String
   seq_value: Hash(); Mod(<<valuecount:1000000000>>); ToString() -> String
-  rw_key: <<keydist:Uniform(0,1000000000)->int>>; ToString() -> String
+  rw_key: <<keydist:Uniform(0,10000000)->int>>; ToString() -> String
   rw_value: Hash(); <<valdist:Uniform(0,1000000000)->int>>; ToString() -> String
 
 blocks:
@@ -79,7 +79,7 @@ blocks:
       phase: main
       type: read
     params:
-      ratio: 5
+      ratio: <<read_ratio:5>>
     statements:
       - main-select: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql/<<keyspace:gqlcf_keyvalue>>
         Accept: "application/json"
@@ -95,7 +95,7 @@ blocks:
       phase: main
       type: write
     params:
-      ratio: 5
+      ratio: <<write_ratio:5>>
     statements:
       - main-write: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8080>><<path_prefix:>>/graphql/<<keyspace:gqlcf_keyvalue>>
         Accept: "application/json"

--- a/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/graphql-schema-first/http-graphql-keyvalue.yaml
@@ -13,9 +13,9 @@ description: |
 
 scenarios:
   default:
-    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
-    - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=http tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
   # Examples
@@ -26,9 +26,9 @@ bindings:
   # http request id
   request_id: ToHashedUUID(); ToString();
 
-  seq_key: Mod(<<keycount:1000000000>>); ToString() -> String
+  seq_key: Mod(<<keycount:10000000>>); ToString() -> String
   seq_value: Hash(); Mod(<<valuecount:1000000000>>); ToString() -> String
-  rw_key: <<keydist:Uniform(0,1000000000)->int>>; ToString() -> String
+  rw_key: <<keydist:Uniform(0,10000000)->int>>; ToString() -> String
   rw_value: Hash(); <<valdist:Uniform(0,1000000000)->int>>; ToString() -> String
 
 blocks:


### PR DESCRIPTION
Relates to https://github.com/nosqlbench/nosqlbench/pull/349

While https://github.com/nosqlbench/nosqlbench/pull/349 fixes the docs-api-keyvalue test, this does a similar set of fixes for http-rest-keyvalue, http-graphql-cql-keyvalue, and http-graphql-keyvalue.

The tabular/timeseries tests have their own special way to match keys with the cycle number, and upon review it looks like they are behaving properly.

Also note that the graphql-related tests do NOT accept 4XX as a valid response, this is because graphql is not ever meant to return 4XX for valid requests.