### PR TITLE
Dockerfile: openjdk:15-alpine -> adoptopenjdk/openjdk15:alpine-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15-alpine
+FROM adoptopenjdk/openjdk15:alpine-slim
 RUN apk --no-cache add curl
 
 COPY nb/target/nb.jar nb.jar


### PR DESCRIPTION
Fix to error 
```

2021-09-13 23:10:52,382 [FJP:1151]            ERROR server-3             - [CMD-FAIL] Command completed with non-zero exit code 134: kubectl --namespace=mypulsar exec --container=nosqlbench nosqlbench-deployment-697fc57d5-2kw5c -- ash -o pipefail -c ' java -jar nb.jar run alias=produce_messages type=pulsar config=/fallout-library/config-txt/config.txt yaml=/fallout-library/pulsar-yaml/pulsar.yaml tags=phase:producer web_url=https://pulsar-proxy:8443/ service_url=pulsar+ssl://pulsar-proxy:6651/ async_api=true optype=msg-send threads=10 --report-graphite-to 10.101.35.80:2003 --metrics-prefix server_node3 cycles=0..1000000 host=dummy-cassandra --show-stacktraces -v --logs-dir /nosqlbench/nb-module-logs-produce_messages --log-histograms /nosqlbench/produce_messages.hdr::5s --log-histostats /nosqlbench/produce_messages.csv::5s 2>&1 | tee /nosqlbench/produce_messages.log'
STDOUT (last 20 lines):
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000003efe, pid=20, tid=45
#
# JRE version: OpenJDK Runtime Environment (15.0+31) (build 15-ea+31)
# Java VM: OpenJDK 64-Bit Server VM (15-ea+31, mixed mode, sharing, tiered, compressed oops, serial gc, linux-amd64)
# Problematic frame:
# C  0x0000000000003efe
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport %p %s %c %d %P %E" (or dumping to //core.20)
#
# An error report file with more information is saved as:
# //hs_err_pid20.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```

Related to #324 and [issue 649](https://github.com/netty/netty-tcnative/issues/649).