### PR TITLE
fixing the path to the uszips realdata

### DIFF
--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/Cities.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/Cities.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class Cities extends CSVSampler {
     @Example("Cities()")
     public Cities() {
-        super("city","n/a","name","simplemaps/uszips");
+        super("city","n/a","name","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CitiesByDensity.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CitiesByDensity.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class CitiesByDensity extends CSVSampler {
     @Example("CitiesByDensity()")
     public CitiesByDensity() {
-        super("city","density","simplemaps/uszips");
+        super("city","density","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CitiesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CitiesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class CitiesByPopulation extends CSVSampler {
     @Example("CitiesByPopulation()")
     public CitiesByPopulation() {
-        super("city","population","simplemaps/uszips");
+        super("city","population","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/Counties.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/Counties.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class Counties extends CSVSampler {
     @Example("Counties()")
     public Counties() {
-        super("city","n/a","name","simplemaps/uszips");
+        super("city","n/a","name","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CountiesByDensity.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CountiesByDensity.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class CountiesByDensity extends CSVSampler {
     @Example("CountiesByDensity()")
     public CountiesByDensity() {
-        super("county_name","density","simplemaps/uszips");
+        super("county_name","density","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CountiesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/CountiesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class CountiesByPopulation extends CSVSampler {
     @Example("CountiesByPopulation()")
     public CountiesByPopulation() {
-        super("county_name","population","simplemaps/uszips");
+        super("county_name","population","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodes.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodes.java
@@ -17,7 +17,7 @@ public class StateCodes extends CSVSampler implements LongFunction<String> {
 
     @Example("StateCodes()")
     public StateCodes() {
-        super("state_id","n/a","name","simplemaps/uszips");
+        super("state_id","n/a","name","data/simplemaps/uszips.csv");
     }
 
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodesByDensity.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodesByDensity.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class StateCodesByDensity extends CSVSampler {
     @Example("StateCodesByDensity()")
     public StateCodesByDensity() {
-        super("state_id","density","simplemaps/uszips");
+        super("state_id","density","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateCodesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class StateCodesByPopulation extends CSVSampler {
     @Example("StateCodesByPopulation()")
     public StateCodesByPopulation() {
-        super("state_id","population","simplemaps/uszips");
+        super("state_id","population","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNames.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNames.java
@@ -17,7 +17,7 @@ public class StateNames extends CSVSampler implements LongFunction<String> {
 
     @Example("StateNames()")
     public StateNames() {
-        super("state_name","n/a","name","simplemaps/uszips");
+        super("state_name","n/a","name","data/simplemaps/uszips.csv");
     }
 
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNamesByDensity.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNamesByDensity.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class StateNamesByDensity extends CSVSampler {
     @Example("StateNamesByDensity()")
     public StateNamesByDensity() {
-        super("state_name","density","simplemaps/uszips");
+        super("state_name","density","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNamesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/StateNamesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class StateNamesByPopulation extends CSVSampler {
     @Example("StateNamesByPopulation()")
     public StateNamesByPopulation() {
-        super("state_name","population","simplemaps/uszips");
+        super("state_name","population","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/TimeZones.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/TimeZones.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class TimeZones extends CSVSampler {
     @Example("Timezones()")
     public TimeZones() {
-        super("timezone","n/a","name","simplemaps/uszips");
+        super("timezone","n/a","name","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/TimeZonesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/TimeZonesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class TimeZonesByPopulation extends CSVSampler {
     @Example("TimezonesByPopulation()")
     public TimeZonesByPopulation() {
-        super("timezone","population","simplemaps/uszips");
+        super("timezone","population","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/ZipCodes.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/ZipCodes.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class ZipCodes extends CSVSampler {
     @Example("ZipCodes()")
     public ZipCodes() {
-        super("zip","n/a","name","simplemaps/uszips");
+        super("zip","n/a","name","data/simplemaps/uszips.csv");
     }
 }

--- a/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/ZipCodesByPopulation.java
+++ b/virtdata-lib-realer/src/main/java/io/nosqlbench/virtdata/library/realer/ZipCodesByPopulation.java
@@ -14,6 +14,6 @@ import io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler;
 public class ZipCodesByPopulation extends CSVSampler {
     @Example("ZipCodesByPopulation()")
     public ZipCodesByPopulation() {
-        super("zip","population","simplemaps/uszips");
+        super("zip","population","data/simplemaps/uszips.csv");
     }
 }


### PR DESCRIPTION
I was getting the following exception when trying to use pre-made binding functions that depend on the `uszips.csv`:

```
Caused by: io.nosqlbench.nb.api.errors.BasicError: Unable to find even a single source for 'NBIO{resolver=[resolver], prefixes=[], names=[simplemaps/uszips.csv], extensions=[]}'
	at io.nosqlbench.nb.api.content.NBIO.one(NBIO.java:235)
	at io.nosqlbench.nb.api.content.NBIO.readReader(NBIO.java:83)
	at io.nosqlbench.nb.api.content.NBIO.readFileDelimCSV(NBIO.java:67)
	at io.nosqlbench.nb.api.content.NBIO.readFileCSV(NBIO.java:63)
	at io.nosqlbench.virtdata.library.basics.shared.distributions.CSVSampler.<init>(CSVSampler.java:124)
	at io.nosqlbench.virtdata.library.realer.Cities.<init>(Cities.java:17)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(Unknown Source)
	at io.nosqlbench.virtdata.core.bindings.VirtDataFunctionResolver.resolveFunctions(VirtDataFunctionResolver.java:100)
	... 64 more

```

I fixed the path, the idea came from the https://github.com/nosqlbench/nosqlbench/commit/409b0d31b293bbd0a30839979e6a41b4af5a6167. Tested in my scenario using `CSVSampler('city','n/a','name','data/simplemaps/uszips.csv')`.