### PR TITLE
Ignore message out-of-order and duplicate check for Shared and Key_Shared

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
@@ -401,11 +401,6 @@ public class PulsarSpace {
         SubscriptionType subscriptionType = getEffectiveSubscriptionType(cycleSubscriptionType);
         String consumerName = getEffectiveConsumerName(cycleConsumerName);
 
-        if ( subscriptionType.equals(SubscriptionType.Exclusive) && (activityDef.getThreads() > 1) ) {
-            throw new RuntimeException("Consumer:: trying to create multiple consumers of " +
-                "\"Exclusive\" subscription type under the same subscription name to the same topic!");
-        }
-
         if (StringUtils.isAnyBlank(cycleTopicName, subscriptionName)) {
             throw new RuntimeException("Consumer:: must specify a topic name and a subscription name");
         }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
@@ -31,6 +31,7 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
 
     private final LongFunction<Consumer<?>> consumerFunc;
     private final LongFunction<Boolean> topicMsgDedupFunc;
+    private final LongFunction<String> subscriptionTypeFunc;
     private final boolean e2eMsProc;
 
     public PulsarConsumerMapper(CommandTemplate cmdTpl,
@@ -42,10 +43,12 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
                                 LongFunction<Supplier<Transaction>> transactionSupplierFunc,
                                 LongFunction<Boolean> topicMsgDedupFunc,
                                 LongFunction<Consumer<?>> consumerFunc,
+                                LongFunction<String> subscriptionTypeFunc,
                                 boolean e2eMsgProc) {
         super(cmdTpl, clientSpace, pulsarActivity, asyncApiFunc, useTransactionFunc, seqTrackingFunc, transactionSupplierFunc);
         this.consumerFunc = consumerFunc;
         this.topicMsgDedupFunc = topicMsgDedupFunc;
+        this.subscriptionTypeFunc = subscriptionTypeFunc;
         this.e2eMsProc = e2eMsgProc;
     }
 
@@ -57,6 +60,7 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
         boolean seqTracking = seqTrackingFunc.apply(value);
         Supplier<Transaction> transactionSupplier = transactionSupplierFunc.apply(value);
         boolean topicMsgDedup = topicMsgDedupFunc.apply(value);
+        String subscriptionType = subscriptionTypeFunc.apply(value);
 
         return new PulsarConsumerOp(
             pulsarActivity,
@@ -66,6 +70,7 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
             transactionSupplier,
             topicMsgDedup,
             consumer,
+            subscriptionType,
             clientSpace.getPulsarSchema(),
             clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds(),
             value,

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerMapper.java
@@ -108,8 +108,8 @@ public class PulsarProducerMapper extends PulsarTransactOpMapper {
             // simulate message out of order
             else if ( simulateMsgOutofOrder ) {
                 int rndmOffset = 2;
-                if (value > rndmOffset)
-                    msgProperties.put(PulsarActivityUtil.MSG_SEQUENCE_ID, String.valueOf(value-rndmOffset));
+                msgProperties.put(PulsarActivityUtil.MSG_SEQUENCE_ID,
+                    String.valueOf((value > rndmOffset) ? (value-rndmOffset) : value));
             }
             // simulate message duplication
             else {

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -497,6 +497,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             transactionSupplierFunc,
             topicMsgDedupFunc,
             consumerFunc,
+            subscription_type_func,
             e2eMsgProc);
     }
 
@@ -586,6 +587,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             // e.g. pulsarAdmin.getPulsarAdmin().topics().getDeduplicationStatus(message.getTopicName())
             brokerMsgDupFunc,
             mtConsumerFunc,
+            subscription_type_func,
             false);
     }
 


### PR DESCRIPTION
TODO: such checks can be applied to Key_Shared subscription. But it needs to be applied at per-key basis. Right now this is function is missing; add it in future release