### PR TITLE
Pulsar driver: Upgrade Pulsar client to 2.8.1 version

### DIFF
--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <pulsar.version>2.8.0</pulsar.version>
+        <pulsar.version>2.8.1</pulsar.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
A lot of bugs have been fixed in 2.8.1 . We are experiencing some odd behavior which could be a Pulsar bug. Upgrading to recent stable version would be helpful.