### PR TITLE
add instrumentation scaffold for payloadRtt

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -40,6 +40,15 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
     // Metrics for NB Pulsar driver milestone: https://github.com/nosqlbench/nosqlbench/milestone/11
     // - end-to-end latency
     private Histogram e2eMsgProcLatencyHistogram;
+
+    /**
+     * A histogram that tracks payload round-trip-time, based on a user-defined field in some sender
+     * system which can be interpreted as millisecond epoch time in the system's local time zone.
+     * This is paired with a field name of the same type to be extracted and reported in a meteric
+     * named 'payload-rtt'.
+     */
+    private Histogram payloadRttHistogram;
+
     // - message out of sequence error counter
     private Counter msgErrOutOfSeqCounter;
     // - message loss counter
@@ -85,6 +94,8 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
         commitTransactionTimer = ActivityMetrics.timer(activityDef, "commit_transaction");
 
         e2eMsgProcLatencyHistogram = ActivityMetrics.histogram(activityDef, "e2e_msg_latency");
+        payloadRttHistogram = ActivityMetrics.histogram(activityDef, "payload_rtt");
+
         msgErrOutOfSeqCounter = ActivityMetrics.counter(activityDef, "err_msg_oos");
         msgErrLossCounter = ActivityMetrics.counter(activityDef, "err_msg_loss");
         msgErrDuplicateCounter = ActivityMetrics.counter(activityDef, "err_msg_dup");
@@ -257,6 +268,7 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
     public Timer getCreateTransactionTimer() { return createTransactionTimer; }
     public Timer getCommitTransactionTimer() { return commitTransactionTimer; }
 
+    public Histogram getPayloadRttHistogram() {return payloadRttHistogram;}
     public Histogram getE2eMsgProcLatencyHistogram() { return e2eMsgProcLatencyHistogram; }
     public Counter getMsgErrOutOfSeqCounter() { return msgErrOutOfSeqCounter; }
     public Counter getMsgErrLossCounter() { return msgErrLossCounter; }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -78,6 +78,10 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
     public void shutdownActivity() {
         super.shutdownActivity();
 
+        if (pulsarCache == null) {
+            return;
+        }
+
         for (PulsarSpace pulsarSpace : pulsarCache.getAssociatedPulsarSpace()) {
             pulsarSpace.shutdownPulsarSpace();
         }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -4,19 +4,21 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
 import io.nosqlbench.driver.pulsar.PulsarActivity;
-import io.nosqlbench.driver.pulsar.exception.*;
+import io.nosqlbench.driver.pulsar.exception.PulsarDriverUnexpectedException;
 import io.nosqlbench.driver.pulsar.util.AvroUtil;
 import io.nosqlbench.driver.pulsar.util.PulsarActivityUtil;
-import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class PulsarConsumerOp implements PulsarOp {
@@ -41,7 +43,10 @@ public class PulsarConsumerOp implements PulsarOp {
 
     // keep track of end-to-end message latency
     private final Histogram e2eMsgProcLatencyHistogram;
+
     private final Function<String, ReceivedMessageSequenceTracker> receivedMessageSequenceTrackerForTopic;
+    private final Histogram payloadRttHistogram;
+    private final String payloadRttTrackingField;
 
     public PulsarConsumerOp(
         PulsarActivity pulsarActivity,
@@ -53,7 +58,8 @@ public class PulsarConsumerOp implements PulsarOp {
         Schema<?> schema,
         int timeoutSeconds,
         boolean e2eMsgProc,
-        Function<String, ReceivedMessageSequenceTracker> receivedMessageSequenceTrackerForTopic)
+        Function<String, ReceivedMessageSequenceTracker> receivedMessageSequenceTrackerForTopic,
+        String payloadRttTrackingField)
     {
         this.pulsarActivity = pulsarActivity;
 
@@ -72,7 +78,9 @@ public class PulsarConsumerOp implements PulsarOp {
         this.transactionCommitTimer = pulsarActivity.getCommitTransactionTimer();
 
         this.e2eMsgProcLatencyHistogram = pulsarActivity.getE2eMsgProcLatencyHistogram();
+        this.payloadRttHistogram = pulsarActivity.getPayloadRttHistogram();
         this.receivedMessageSequenceTrackerForTopic = receivedMessageSequenceTrackerForTopic;
+        this.payloadRttTrackingField = payloadRttTrackingField;
     }
 
     private void checkAndUpdateMessageErrorCounter(Message message) {
@@ -138,9 +146,16 @@ public class PulsarConsumerOp implements PulsarOp {
                     }
                 }
 
+                if (!payloadRttTrackingField.isEmpty()) {
+                    // TODO: Extract the extractedSendTime from the payload and convert it to a long.
+                    long extractedSendTime = 0L;
+                    long delta = System.currentTimeMillis()-extractedSendTime;
+                    payloadRttHistogram.update(delta);
+                }
+
                 // keep track end-to-end message processing latency
-                long e2eMsgLatency = System.currentTimeMillis() - message.getPublishTime();
                 if (e2eMsgProc) {
+                    long e2eMsgLatency = System.currentTimeMillis() - message.getPublishTime();
                     e2eMsgProcLatencyHistogram.update(e2eMsgLatency);
                 }
 
@@ -220,8 +235,8 @@ public class PulsarConsumerOp implements PulsarOp {
                         }
                     }
 
-                    long e2eMsgLatency = System.currentTimeMillis() - message.getPublishTime();
                     if (e2eMsgProc) {
+                        long e2eMsgLatency = System.currentTimeMillis() - message.getPublishTime();
                         e2eMsgProcLatencyHistogram.update(e2eMsgLatency);
                     }
 

--- a/engine-api/src/main/java/io/nosqlbench/engine/api/templating/CommandTemplate.java
+++ b/engine-api/src/main/java/io/nosqlbench/engine/api/templating/CommandTemplate.java
@@ -105,7 +105,7 @@ public class CommandTemplate {
             for (Function<String, Map<String, String>> parser : parserlist) {
                 Map<String, String> parsed = parser.apply(oneline);
                 if (parsed != null) {
-                    logger.debug("parsed request: " + parsed.toString());
+                    logger.debug("parsed request: " + parsed);
                     cmd.putAll(parsed);
                     didParse = true;
                     break;
@@ -290,5 +290,20 @@ public class CommandTemplate {
             }
         }
         return true;
+    }
+
+    /**
+     * This should only be used to provide a view of a field definition, never for actual use in a payload.
+     * @param varname The field name which you want to explain
+     * @return A string representation of the field name
+     */
+    public String getFieldDescription(String varname) {
+        if (this.isDynamic(varname)) {
+            return "dynamic: " + this.dynamics.get(varname).toString();
+        } else if (this.isStatic(varname)) {
+            return "static: " + this.getStatic(varname);
+        } else {
+            return "UNDEFINED";
+        }
     }
 }


### PR DESCRIPTION
This puts in a separate rtt tracking mechanism which may work with different sender and receiver types, since it can rely on a payload field instead of intrinsic elements of the pulsar API. I have left the last piece out -- the extraction and conversion of the send time value.