### PR TITLE
README and minor code cleanup

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerMapper.java
@@ -28,8 +28,6 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
     private final static Logger logger = LogManager.getLogger(PulsarProducerMapper.class);
 
     private final LongFunction<Consumer<?>> consumerFunc;
-    private final LongFunction<Boolean> topicMsgDedupFunc;
-    private final LongFunction<String> subscriptionTypeFunc;
     private final boolean e2eMsProc;
 
     public PulsarConsumerMapper(CommandTemplate cmdTpl,
@@ -39,14 +37,10 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
                                 LongFunction<Boolean> useTransactionFunc,
                                 LongFunction<Boolean> seqTrackingFunc,
                                 LongFunction<Supplier<Transaction>> transactionSupplierFunc,
-                                LongFunction<Boolean> topicMsgDedupFunc,
                                 LongFunction<Consumer<?>> consumerFunc,
-                                LongFunction<String> subscriptionTypeFunc,
                                 boolean e2eMsgProc) {
         super(cmdTpl, clientSpace, pulsarActivity, asyncApiFunc, useTransactionFunc, seqTrackingFunc, transactionSupplierFunc);
         this.consumerFunc = consumerFunc;
-        this.topicMsgDedupFunc = topicMsgDedupFunc;
-        this.subscriptionTypeFunc = subscriptionTypeFunc;
         this.e2eMsProc = e2eMsgProc;
     }
 
@@ -57,22 +51,16 @@ public class PulsarConsumerMapper extends PulsarTransactOpMapper {
         boolean asyncApi = asyncApiFunc.apply(value);
         boolean useTransaction = useTransactionFunc.apply(value);
         Supplier<Transaction> transactionSupplier = transactionSupplierFunc.apply(value);
-        boolean topicMsgDedup = topicMsgDedupFunc.apply(value);
-        String subscriptionType = subscriptionTypeFunc.apply(value);
 
         return new PulsarConsumerOp(
-            this,
             pulsarActivity,
             asyncApi,
             useTransaction,
             seqTracking,
             transactionSupplier,
-            topicMsgDedup,
             consumer,
-            subscriptionType,
             clientSpace.getPulsarSchema(),
             clientSpace.getPulsarClientConf().getConsumerTimeoutSeconds(),
-            value,
             e2eMsProc,
             this::getReceivedMessageSequenceTracker);
     }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -23,7 +23,6 @@ public class PulsarConsumerOp implements PulsarOp {
 
     private final static Logger logger = LogManager.getLogger(PulsarConsumerOp.class);
 
-    private final PulsarConsumerMapper consumerMapper;
     private final PulsarActivity pulsarActivity;
 
     private final boolean asyncPulsarOp;
@@ -31,13 +30,10 @@ public class PulsarConsumerOp implements PulsarOp {
     private final boolean seqTracking;
     private final Supplier<Transaction> transactionSupplier;
 
-    private final boolean topicMsgDedup;
     private final Consumer<?> consumer;
-    private final String subscriptionType;
     private final Schema<?> pulsarSchema;
     private final int timeoutSeconds;
     private final boolean e2eMsgProc;
-    private final long curCycleNum;
 
     private final Counter bytesCounter;
     private final Histogram messageSizeHistogram;
@@ -48,22 +44,17 @@ public class PulsarConsumerOp implements PulsarOp {
     private final Function<String, ReceivedMessageSequenceTracker> receivedMessageSequenceTrackerForTopic;
 
     public PulsarConsumerOp(
-        PulsarConsumerMapper consumerMapper,
         PulsarActivity pulsarActivity,
         boolean asyncPulsarOp,
         boolean useTransaction,
         boolean seqTracking,
         Supplier<Transaction> transactionSupplier,
-        boolean topicMsgDedup,
         Consumer<?> consumer,
-        String subscriptionType,
         Schema<?> schema,
         int timeoutSeconds,
-        long curCycleNum,
         boolean e2eMsgProc,
         Function<String, ReceivedMessageSequenceTracker> receivedMessageSequenceTrackerForTopic)
     {
-        this.consumerMapper = consumerMapper;
         this.pulsarActivity = pulsarActivity;
 
         this.asyncPulsarOp = asyncPulsarOp;
@@ -71,12 +62,9 @@ public class PulsarConsumerOp implements PulsarOp {
         this.seqTracking = seqTracking;
         this.transactionSupplier = transactionSupplier;
 
-        this.topicMsgDedup = topicMsgDedup;
         this.consumer = consumer;
-        this.subscriptionType = subscriptionType;
         this.pulsarSchema = schema;
         this.timeoutSeconds = timeoutSeconds;
-        this.curCycleNum = curCycleNum;
         this.e2eMsgProc = e2eMsgProc;
 
         this.bytesCounter = pulsarActivity.getBytesCounter();

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -129,17 +129,6 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
         }
         logger.info("seq_tracking: {}", seqTrackingFunc.apply(0));
 
-        // Doc-level parameter: msg_dedup_broker
-        LongFunction<Boolean> brokerMsgDedupFunc = (l) -> false;
-        if (cmdTpl.containsKey(PulsarActivityUtil.DOC_LEVEL_PARAMS.MSG_DEDUP_BROKER.label)) {
-            if (cmdTpl.isStatic(PulsarActivityUtil.DOC_LEVEL_PARAMS.MSG_DEDUP_BROKER.label))
-                brokerMsgDedupFunc = (l) -> BooleanUtils.toBoolean(cmdTpl.getStatic(PulsarActivityUtil.DOC_LEVEL_PARAMS.MSG_DEDUP_BROKER.label));
-            else
-                throw new PulsarDriverParamException("[resolve()] \"" + PulsarActivityUtil.DOC_LEVEL_PARAMS.MSG_DEDUP_BROKER.label + "\" parameter cannot be dynamic!");
-        }
-        logger.info("msg_dedup_broker: {}", seqTrackingFunc.apply(0));
-
-
         // TODO: Complete implementation for websocket-producer and managed-ledger
         // Admin operation: create/delete tenant
         if ( StringUtils.equalsIgnoreCase(stmtOpType, PulsarActivityUtil.OP_TYPES.ADMIN_TENANT.label) ) {
@@ -165,7 +154,6 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
                 asyncApiFunc,
                 useTransactionFunc,
                 seqTrackingFunc,
-                brokerMsgDedupFunc,
                 false);
         }
         // Regular/non-admin operation: single message consuming from multiple-topics (consumer)
@@ -175,8 +163,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
                 topicUriFunc,
                 asyncApiFunc,
                 useTransactionFunc,
-                seqTrackingFunc,
-                brokerMsgDedupFunc);
+                seqTrackingFunc);
         }
         // Regular/non-admin operation: single message consuming a single topic (reader)
         else if (StringUtils.equalsIgnoreCase(stmtOpType, PulsarActivityUtil.OP_TYPES.MSG_READ.label)) {
@@ -206,7 +193,6 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
                 asyncApiFunc,
                 useTransactionFunc,
                 seqTrackingFunc,
-                brokerMsgDedupFunc,
                 true);
         }
         // Invalid operation type
@@ -425,7 +411,6 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
         LongFunction<Boolean> async_api_func,
         LongFunction<Boolean> useTransactionFunc,
         LongFunction<Boolean> seqTrackingFunc,
-        LongFunction<Boolean> brokerMsgDupFunc,
         boolean e2eMsgProc
     ) {
         LongFunction<String> subscription_name_func;
@@ -458,12 +443,6 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
         LongFunction<Supplier<Transaction>> transactionSupplierFunc =
             (l) -> clientSpace.getTransactionSupplier(); //TODO make it dependant on current cycle?
 
-        // TODO: Ignore namespace and topic level dedup check on the fly
-        //   this will impact the consumer performance significantly
-        //       Consider using caching or Memoizer in the future?
-        //   (https://www.baeldung.com/guava-memoizer)
-        LongFunction<Boolean> topicMsgDedupFunc = brokerMsgDupFunc;
-
         LongFunction<Consumer<?>> consumerFunc = (l) ->
             clientSpace.getConsumer(
                 topic_uri_func.apply(l),
@@ -480,9 +459,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             useTransactionFunc,
             seqTrackingFunc,
             transactionSupplierFunc,
-            topicMsgDedupFunc,
             consumerFunc,
-            subscription_type_func,
             e2eMsgProc);
     }
 
@@ -491,8 +468,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
         LongFunction<String> topic_uri_func,
         LongFunction<Boolean> async_api_func,
         LongFunction<Boolean> useTransactionFunc,
-        LongFunction<Boolean> seqTrackingFunc,
-        LongFunction<Boolean> brokerMsgDupFunc
+        LongFunction<Boolean> seqTrackingFunc
     ) {
         // Topic list (multi-topic)
         LongFunction<String> topic_names_func;
@@ -562,17 +538,7 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
             useTransactionFunc,
             seqTrackingFunc,
             transactionSupplierFunc,
-            // For multi-topic subscription message consumption,
-            // - Only consider broker-level message deduplication setting
-            // - Ignore namespace- and topic-level message deduplication setting
-            //
-            // This is because Pulsar is able to specify a list of topics from
-            // different namespaces. In theory, we can get topic deduplication
-            // status from each message, but this will be too much overhead.
-            // e.g. pulsarAdmin.getPulsarAdmin().topics().getDeduplicationStatus(message.getTopicName())
-            brokerMsgDupFunc,
             mtConsumerFunc,
-            subscription_type_func,
             false);
     }
 

--- a/driver-pulsar/src/main/resources/activities/pulsar_admin_namespace.yaml
+++ b/driver-pulsar/src/main/resources/activities/pulsar_admin_namespace.yaml
@@ -6,7 +6,7 @@ bindings:
 params:
   # "true" - asynchronous Pulsar Admin API
   # "false" - synchronous Pulsar Admin API
-  async_api: "true"
+  async_api: "false"
   # "true" - delete namespace
   # "false" - create namespace
   admin_delop: "false"

--- a/driver-pulsar/src/main/resources/activities/pulsar_admin_topic.yaml
+++ b/driver-pulsar/src/main/resources/activities/pulsar_admin_topic.yaml
@@ -8,7 +8,7 @@ params:
   topic_uri: "persistent://{tenant}/{namespace}/{core_topic_name}"
   # "true" - asynchronous Pulsar Admin API
   # "false" - synchronous Pulsar Admin API
-  async_api: "true"
+  async_api: "false"
   # "true" - delete topic
   # "false" - create topic
   admin_delop: "false"

--- a/driver-pulsar/src/main/resources/design_revisit.md
+++ b/driver-pulsar/src/main/resources/design_revisit.md
@@ -1,0 +1,89 @@
+# TODO : Design Revisit -- Advanced Driver Features
+
+**NOTE**: The following text is based on the original multi-layer API
+caching design which is not fully implemented at the moment. We need to
+revisit the original design at some point in order to achieve maximum
+testing flexibility.
+
+To summarize, the original caching design has the following key
+requirements:
+
+* **Requirement 1**: Each NB Pulsar activity is able to launch and cache
+  multiple **client spaces**
+* **Requirement 2**: Each client space can launch and cache multiple
+  Pulsar operators of the same type (producer, consumer, etc.)
+* **Requirement 3**: The size of each Pulsar operator specific cached
+  space can be configurable.
+
+In the current implementation, only requirement 2 is implemented.
+
+* For requirement 1, the current implementation only supports one client
+  space per NB Pulsar activity
+* For requirement 3, the cache space size is not configurable (no limit at
+  the moment)
+
+## Other Activity Parameters
+
+- **maxcached** - A default value to be applied to `max_clients`,
+  `max_producers`, `max_consumers`.
+    - default: `max_cached=100`
+- **max_clients** - Clients cache size. This is the number of client
+  instances which are allowed to be cached in the NoSQLBench client
+  runtime. The clients cache automatically maintains a cache of unique
+  client instances internally. default: _maxcached_
+- **max_operators** - Producers/Consumers/Readers cache size (per client
+  instance). Limits the number of instances which are allowed to be cached
+  per client instance. default: _maxcached_
+
+## API Caching
+
+This driver is tailored around the multi-tenancy and topic naming scheme
+that is part of Apache Pulsar. Specifically, you can create an arbitrary
+number of client instances, producers (per client), and consumers (per
+client) depending on your testing requirements.
+
+Further, the topic URI is composed from the provided qualifiers of
+`persistence`, `tenant`, `namespace`, and `topic`, or you can provide a
+fully-composed value in the `persistence://tenant/namespace/topic`
+form.
+
+### Instancing Controls
+
+Normative usage of the Apache Pulsar API follows a strictly enforced
+binding of topics to producers and consumers. As well, clients may be
+customized with different behavior for advanced testing scenarios. There
+is a significant variety of messaging and concurrency schemes seen in
+modern architectures. Thus, it is important that testing tools rise to the
+occasion by letting users configure their testing runtimes to emulate
+applications as they are found in practice. To this end, the NoSQLBench
+driver for Apache Pulsar provides a set controls within its op template
+format which allow for flexible yet intuitive instancing in the client
+runtime. This is enabled directly by using nominative variables for
+instance names where needed. When the instance names are not provided for
+an operation, defaults are used to emulate a simple configuration.
+
+Since this is a new capability in a NoSQLBench driver, how it works is
+explained below:
+
+When a pulsar cycles is executed, the operation is synthesized from the op
+template fields as explained below under _Op Fields_. This happens in a
+specific order:
+
+1. The client instance name is resolved. If a `client` field is provided,
+   this is taken as the client instance name. If not, it is set
+   to `default`.
+2. The named client instance is fetched from the cache, or created and
+   cached if it does not yet exist.
+3. The topic_uri is resolved. This is the value to be used with
+   `.topic(...)` calls in the API. The op fields below explain how to
+   control this value.
+4. For _send_ operations, a producer is named and created if needed. By
+   default, the producer is named after the topic_uri above. You can
+   override this by providing a value for `producer`.
+5. For _recv_ operations, a consumer is named and created if needed. By
+   default, the consumer is named after the topic_uri above. You can
+   override this by providing a value for `consumer`.
+
+The most important detail for understanding the instancing controls is
+that clients, producers, and consumers are all named and cached in the
+specific order above.


### PR DESCRIPTION
- Clean up README file
- Remove unused variables that were used for the old version of message loss/out-of-sequence/duplication check