### PR TITLE
Document API search endpoint workloads

### DIFF
--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.md
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.md
@@ -50,18 +50,19 @@ The example JSON looks like:
 ## Filters tested
 
 The advanced search workload can test the following `where` clauses:
-- in: match1 IN [0]
-- not-in: match2 NOT IN ["false"]
-- mem-and: match2 EQ "true" AND match3 NOT EQ false
-- mem-or: match1 LT 1 OR match3 EXISTS
-- complex1: match1 EQ 0 AND (match2 EQ "true" OR match3 EQ false)
-- complex2: (match1 LTE 0 OR match2 EQ "false") AND (match2 EQ "false" OR match3 EQ true)
-- complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
+- in: `match1 IN [0]`
+- not-in: `match2 NOT IN ["false"]`
+- mem-and: `match2 EQ "true" AND match3 NOT EQ false`
+- mem-or: `match1 LT 1 OR match3 EXISTS`
+- complex1: `match1 EQ 0 AND (match2 EQ "true" OR match3 EQ false)`
+- complex2: `(match1 LTE 0 OR match2 EQ "false") AND (match2 EQ "false" OR match3 EQ true)`
+- complex3: `(match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)`
 
 ## Workload Parameters
 
 - `docscount` - the number of documents to write during rampup (default: `10_000_000`)
 - `docpadding` - the number of fields to add to each document; useful for writing larger documents. A value of e.g. `5` would make each document have 20 leaf values, instead of 15. (default: `0`)
 - `match-ratio` - a value between 0 and 1 detailing what ratio of the documents written should match the search parameters. If match-ratio is e.g. `0.1` then approximately one-tenth of the documents will have `match1`, `match2`, and `match3` values that are `0`, `"true"`, and `true`, respectively. (default: `0.01`)
+- `fields` - the URL-encoded value for `fields` that you would send to the Docs API. This restricts the fields returned during benchmarking.
 
 

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.md
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.md
@@ -1,0 +1,67 @@
+---
+title: Documents API Search Advanced
+weight: 2
+---
+
+## Description
+
+The Documents API Search Advanced workflow targets Stargate's Documents API using generated JSON documents. Specifically, it looks to benchmark more advanced search cases, using both complex boolean logic and filters that aren't natively supported by the underlying data store.
+By default, the documents used are sharing the same structure and are approximately half a kilobyte in size each:
+
+* Each document has 15 leaf values, with a maximum depth of 3
+* there is at least one `string`, `boolean`, `number` and `null` leaf
+* there is one array with `double` values and one with `string` values
+* there is one empty array and one empty map
+
+The example JSON looks like:
+
+```json
+{
+  "user_id":"56fd76f6-081d-401a-85eb-b1d9e5bba058",
+  "created_on":1476743286,
+  "full_name":"Andrew Daniels",
+  "married":true,
+  "address":{
+    "primary":{
+      "cc":"IO",
+      "city":"Okmulgee"
+    },
+    "secondary":{
+
+    }
+  },
+  "coordinates":[
+    64.65964627052323,
+    -122.35334535072856
+  ],
+  "children":[
+
+  ],
+  "friends":[
+    "3df498b1-9568-4584-96fd-76f6081da01a"
+  ],
+  "debt":null,
+  "match1": 0, // or 1000
+  "match2": "true", // or "false"
+  "match3": true // or false
+}
+```
+
+## Filters tested
+
+The advanced search workload can test the following `where` clauses:
+- in: match1 IN [0]
+- not-in: match2 NOT IN ["false"]
+- mem-and: match2 EQ "true" AND match3 NOT EQ false
+- mem-or: match1 LT 1 OR match3 EXISTS
+- complex1: match1 EQ 0 AND (match2 EQ "true" OR match3 EQ false)
+- complex2: (match1 LTE 0 OR match2 EQ "false") AND (match2 EQ "false" OR match3 EQ true)
+- complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
+
+## Workload Parameters
+
+- `docscount` - the number of documents to write during rampup (default: `10_000_000`)
+- `docpadding` - the number of fields to add to each document; useful for writing larger documents. A value of e.g. `5` would make each document have 20 leaf values, instead of 15. (default: `0`)
+- `match-ratio` - a value between 0 and 1 detailing what ratio of the documents written should match the search parameters. If match-ratio is e.g. `0.1` then approximately one-tenth of the documents will have `match1`, `match2`, and `match3` values that are `0`, `"true"`, and `true`, respectively. (default: `0.01`)
+
+

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
@@ -16,7 +16,7 @@ description: |
 # complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
 scenarios:
   schema:             run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-  rampup-write:       run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docpadding=TEMPLATE(docpadding,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-write:       run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
   rampup-read:        run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main:               run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main-in:            run driver=http tags==phase:main,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
@@ -16,7 +16,7 @@ description: |
 # complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
 scenarios:
   schema:             run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-  rampup-write:       run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-write:       run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docpadding=TEMPLATE(docpadding,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
   rampup-read:        run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main:               run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main-in:            run driver=http tags==phase:main,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
@@ -50,11 +50,11 @@ bindings:
   lng: Hash() -> long; Uniform(-180d, 180d)
   friend_id: Add(-1); ToHashedUUID(); ToString() -> String
 
-  match1: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return 0; } return (int)(Math.random() * 10000 + 1000);') -> long
-  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
-  match3: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
+  match1: Identity(); CoinFunc(<<match-ratio>>, FixedValue(0), FixedValue(1000))
+  match2: Identity(); CoinFunc(<<match-ratio>>, FixedValue("true"), FixedValue("false"))
+  match3: Identity(); CoinFunc(<<match-ratio>>, FixedValue("true"), FixedValue("false"))
   
-  additional_fields: Expr('str="";for (int i=0; i < TEMPLATE(docsize,15) - 15; i++) { if (str == "") { str = "," }; str+="\"value"+i+"\":0"; if (i < TEMPLATE(docsize,15) - 16) {str += ","}} return str;') -> String
+  additional_fields: ListSizedStepped(<<docpadding:0>>,Template("\"{}\":{}",Identity(),Identity())); ToString(); ReplaceAll('\[\"', ',\"'); ReplaceAll('\[', ''); ReplaceAll('\]', '') -> String
 
 blocks:
   - tags:

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
@@ -1,0 +1,315 @@
+# nb -v run driver=http yaml=http-docsapi-search-basic tags=phase:schema stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+
+description: |
+  This workload emulates advanced search filter combinations for the Stargate Documents API.
+  During the rampup phase, it generates documents, writes them to a table, and then warms up the search paths.
+  During the main phase it performs various basic search filters and times their execution.
+  Note that stargate_port should reflect the port where the Docs API is exposed (defaults to 8082).
+
+# These are the filter combinations tested in this workload, and their names:
+# in: match1 IN [0]
+# not-in: match2 NOT IN ["false"]
+# mem-and: match2 EQ "true" AND match3 NOT EQ false
+# mem-or: match1 LT 1 OR match3 EXISTS
+# complex1: match1 EQ 0 AND (match2 EQ "true" OR match3 EQ false)
+# complex2: (match1 LTE 0 OR match2 EQ "false") AND (match2 EQ "false" OR match3 EQ true)
+# complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
+scenarios:
+  schema:             run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
+  rampup-write:       run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-read:        run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main:               run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-in:            run driver=http tags==phase:main,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-not-in:        run driver=http tags==phase:main,filter:not-in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-mem-and:       run driver=http tags==phase:main,filter:mem-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-mem-or:        run driver=http tags==phase:main,filter:mem-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-complex1:      run driver=http tags==phase:main,filter:complex1 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-complex2:      run driver=http tags==phase:main,filter:complex2 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-complex3:      run driver=http tags==phase:main,filter:complex3 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+
+bindings:
+  # To enable an optional weighted set of hosts in place of a load balancer
+  # Examples
+  #   single host: stargate_host=host1
+  #   multiple hosts: stargate_host=host1,host2,host3
+  #   multiple weighted hosts: stargate_host=host1:3,host2:7
+  weighted_hosts: WeightedStrings('<<stargate_host:stargate>>')
+  # http request id
+  request_id: ToHashedUUID(); ToString();
+
+  seq_key: Mod(<<docscount:10000000>>); ToString() -> String
+  random_key: Uniform(0,<<docscount:10000000>>); ToString() -> String
+
+  user_id: ToHashedUUID(); ToString() -> String
+  created_on: Uniform(1262304000,1577836800) -> long
+  full_name: FullNames()
+  married: ModuloToBoolean()
+  city: Cities()
+  country_code: CountryCodes()
+  lat: Uniform(-180d, 180d)
+  lng: Hash() -> long; Uniform(-180d, 180d)
+  friend_id: Add(-1); ToHashedUUID(); ToString() -> String
+
+  match1: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return 0; } return (int)(Math.random() * 10000 + 1000);') -> long
+  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
+  match3: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
+  
+  additional_fields: Expr('str="";for (int i=0; i < TEMPLATE(docsize,15) - 15; i++) { if (str == "") { str = "," }; str+="\"value"+i+"\":0"; if (i < TEMPLATE(docsize,15) - 16) {str += ","}} return str;') -> String
+
+blocks:
+  - tags:
+      phase: schema
+    statements:
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<keyspace:docs_search_advanced>>",
+              "replicas": <<rf:1>>
+          }
+        tags:
+          name: create-keyspace
+
+      - delete-docs-collection: DELETE <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        tags:
+          name: delete-table
+        ok-status: "[2-4][0-9][0-9]"
+
+      - create-docs-collection: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:docs_collection>>"
+          }
+        tags:
+          name: create-table
+  
+  - name: rampup-write
+    tags:
+      phase: rampup-write
+    statements:
+      - rampup-insert: PUT <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>/{seq_key}
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+            "user_id":      "{user_id}",
+            "created_on":   {created_on},
+            "full_name":    "{full_name}",
+            "married":      {married},
+            "address": {
+              "primary": {
+                  "city":   "{city}",
+                  "cc":     "{country_code}"
+              },
+              "secondary":  {}
+            },
+            "coordinates": [
+                            {lat},
+                            {lng}
+            ],
+            "children":     [],
+            "friends": [
+                            "{friend_id}"
+            ],
+            "debt":         null,
+            "match1":       {match1},
+            "match2":       "{match2}",
+            "match3":       {match3}
+            {additional_fields}
+          }
+        tags:
+          name: rampup-insert
+  
+  - name: rampup-in
+    tags:
+      phase: rampup-read
+      filter: in
+    statements:
+      - rampup-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-in
+  
+  - name: rampup-not-in
+    tags:
+      phase: rampup-read
+      filter: not-in
+    statements:
+      - rampup-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-not-in
+
+  - name: rampup-mem-and
+    tags:
+      phase:  rampup-read
+      filter: mem-and
+    statements:
+      - rampup-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-mem-and
+
+  - name: rampup-mem-or
+    tags:
+      phase:  rampup-read
+      filter: mem-or
+    statements:
+      - rampup-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-mem-or
+
+  - name: rampup-complex1
+    tags:
+      phase:  rampup-read
+      filter: complex1
+    statements:
+      - rampup-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-complex1
+  
+  - name: rampup-complex2
+    tags:
+      phase:  rampup-read
+      filter: complex2
+    statements:
+      - rampup-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-complex2
+
+  - name: rampup-complex3
+    tags:
+      phase:  rampup-read
+      filter: complex3
+    statements:
+      - rampup-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-complex3
+
+  - name: main-in
+    tags:
+      phase: main
+      filter: in
+    statements:
+      - main-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-in
+  
+  - name: main-not-in
+    tags:
+      phase: main
+      filter: not-in
+    statements:
+      - main-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-not-in
+
+  - name: main-mem-and
+    tags:
+      phase:  main
+      filter: mem-and
+    statements:
+      - main-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-mem-and
+
+  - name: main-mem-or
+    tags:
+      phase:  main
+      filter: mem-or
+    statements:
+      - main-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-mem-or
+
+  - name: main-complex1
+    tags:
+      phase:  main
+      filter: complex1
+    statements:
+      - main-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-complex1
+  
+  - name: main-complex2
+    tags:
+      phase:  main
+      filter: complex2
+    statements:
+      - main-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-complex2
+
+  - name: main-complex3
+    tags:
+      phase:  main
+      filter: complex3
+    statements:
+      - main-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-complex3

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
@@ -1,4 +1,4 @@
-# nb -v run driver=http yaml=http-docsapi-search-basic tags=phase:schema stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+# nb -v run driver=http yaml=http-docsapi-search-advanced tags=phase:schema stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
 
 description: |
   This workload emulates advanced search filter combinations for the Stargate Documents API.
@@ -137,6 +137,7 @@ blocks:
       phase: rampup-read
       filter: in
     statements:
+      # where={"match1":{"$in":[0]}}
       - rampup-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -150,6 +151,7 @@ blocks:
       phase: rampup-read
       filter: not-in
     statements:
+      # where={"match2":{"$nin":["false"]}}
       - rampup-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -163,6 +165,7 @@ blocks:
       phase:  rampup-read
       filter: mem-and
     statements:
+      # where={"match2":{"$eq":"true"},"match3":{"$ne": false}}
       - rampup-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -176,6 +179,7 @@ blocks:
       phase:  rampup-read
       filter: mem-or
     statements:
+      # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}
       - rampup-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -189,6 +193,7 @@ blocks:
       phase:  rampup-read
       filter: complex1
     statements:
+      # where={"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}
       - rampup-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -202,6 +207,7 @@ blocks:
       phase:  rampup-read
       filter: complex2
     statements:
+      # where={"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
       - rampup-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -215,6 +221,7 @@ blocks:
       phase:  rampup-read
       filter: complex3
     statements:
+      # where={"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
       - rampup-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -228,6 +235,7 @@ blocks:
       phase: main
       filter: in
     statements:
+      # where={"match1":{"$in":[0]}}
       - main-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -241,6 +249,7 @@ blocks:
       phase: main
       filter: not-in
     statements:
+      # where={"match2":{"$nin":["false"]}}
       - main-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -254,6 +263,7 @@ blocks:
       phase:  main
       filter: mem-and
     statements:
+      # where={"match2":{"$eq":"true"},"match3":{"$ne": false}}
       - main-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -267,6 +277,7 @@ blocks:
       phase:  main
       filter: mem-or
     statements:
+      # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}
       - main-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -280,6 +291,7 @@ blocks:
       phase:  main
       filter: complex1
     statements:
+      # where={"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}
       - main-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -293,6 +305,7 @@ blocks:
       phase:  main
       filter: complex2
     statements:
+      # where={"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
       - main-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -306,6 +319,7 @@ blocks:
       phase:  main
       filter: complex3
     statements:
+      # where={"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
       - main-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-advanced.yaml
@@ -138,7 +138,7 @@ blocks:
       filter: in
     statements:
       # where={"match1":{"$in":[0]}}
-      - rampup-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$in":[0]}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -152,7 +152,7 @@ blocks:
       filter: not-in
     statements:
       # where={"match2":{"$nin":["false"]}}
-      - rampup-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match2":{"$nin":["false"]}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -166,7 +166,7 @@ blocks:
       filter: mem-and
     statements:
       # where={"match2":{"$eq":"true"},"match3":{"$ne": false}}
-      - rampup-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match2":{"$eq":"true"},"match3":{"$ne":false}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -180,7 +180,7 @@ blocks:
       filter: mem-or
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}
-      - rampup-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -194,7 +194,7 @@ blocks:
       filter: complex1
     statements:
       # where={"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}
-      - rampup-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -208,7 +208,7 @@ blocks:
       filter: complex2
     statements:
       # where={"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
-      - rampup-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -222,7 +222,7 @@ blocks:
       filter: complex3
     statements:
       # where={"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
-      - rampup-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -236,7 +236,7 @@ blocks:
       filter: in
     statements:
       # where={"match1":{"$in":[0]}}
-      - main-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24in%22%3A%5B0%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$in":[0]}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -250,7 +250,7 @@ blocks:
       filter: not-in
     statements:
       # where={"match2":{"$nin":["false"]}}
-      - main-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24nin%22%3A%5B%22false%22%5D%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-not-in: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match2":{"$nin":["false"]}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -264,7 +264,7 @@ blocks:
       filter: mem-and
     statements:
       # where={"match2":{"$eq":"true"},"match3":{"$ne": false}}
-      - main-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24ne%22%3A%20false%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-mem-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match2":{"$eq":"true"},"match3":{"$ne":false}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -278,7 +278,7 @@ blocks:
       filter: mem-or
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}
-      - main-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24exists%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-mem-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match3":{"$exists":true}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -292,7 +292,7 @@ blocks:
       filter: complex1
     statements:
       # where={"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}
-      - main-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Afalse%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-complex1: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$and":[{"match1":{"$eq":0}},{"$or":[{"match2":{"$eq":"true"}},{"match3":{"$eq":false}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -306,7 +306,7 @@ blocks:
       filter: complex2
     statements:
       # where={"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
-      - main-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%5D%7D%2C%7B%22%24or%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-complex2: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$and":[{"$or":[{"match1":{"$lte":0}},{"match2":{"$eq":"false"}}]},{"$or":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -320,7 +320,7 @@ blocks:
       filter: complex3
     statements:
       # where={"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}
-      - main-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22%24and%22%3A%5B%7B%22match1%22%3A%7B%22%24lte%22%3A0%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%5D%7D%2C%7B%22%24and%22%3A%5B%7B%22match2%22%3A%7B%22%24eq%22%3A%22false%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-complex3: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_advanced>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"$and":[{"match1":{"$lte":0}},{"match2":{"$eq":"true"}}]},{"$and":[{"match2":{"$eq":"false"}},{"match3":{"$eq":true}}]}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.md
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.md
@@ -50,11 +50,11 @@ The example JSON looks like:
 ## Filters tested
 
 The basic search workload can test the following `where` clauses:
-- eq: match3 EQ true
-- lt: match1 LT 1
-- and: match1 LT 1 AND match2 EQ "true"
-- or: match1 LT 1 OR match2 EQ "true" or match3 EQ true
-- or-single-match: match1 LT 1 OR match2 EQ "notamatch"
+- eq: `match3 EQ true`
+- lt: `match1 LT 1`
+- and: `match1 LT 1 AND match2 EQ "true"`
+- or: `match1 LT 1 OR match2 EQ "true" or match3 EQ true`
+- or-single-match: `match1 LT 1 OR match2 EQ "notamatch"`
 
 ## Workload Parameters
 

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.md
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.md
@@ -1,0 +1,66 @@
+---
+title: Documents API Search Basic
+weight: 2
+---
+
+## Description
+
+The Documents API Search Basic workflow targets Stargate's Documents API using generated JSON documents. Specifically, it looks to benchmark basic search cases, using the filters that are supported by the underlying data store.
+By default, the documents used are sharing the same structure and are approximately half a kilobyte in size each:
+
+* Each document has 15 leaf values, with a maximum depth of 3
+* there is at least one `string`, `boolean`, `number` and `null` leaf
+* there is one array with `double` values and one with `string` values
+* there is one empty array and one empty map
+
+The example JSON looks like:
+
+```json
+{
+  "user_id":"56fd76f6-081d-401a-85eb-b1d9e5bba058",
+  "created_on":1476743286,
+  "full_name":"Andrew Daniels",
+  "married":true,
+  "address":{
+    "primary":{
+      "cc":"IO",
+      "city":"Okmulgee"
+    },
+    "secondary":{
+
+    }
+  },
+  "coordinates":[
+    64.65964627052323,
+    -122.35334535072856
+  ],
+  "children":[
+
+  ],
+  "friends":[
+    "3df498b1-9568-4584-96fd-76f6081da01a"
+  ],
+  "debt":null,
+  "match1": 0, // or 1000
+  "match2": "true", // or "false"
+  "match3": true // or false
+}
+```
+
+## Filters tested
+
+The basic search workload can test the following `where` clauses:
+- eq: match3 EQ true
+- lt: match1 LT 1
+- and: match1 LT 1 AND match2 EQ "true"
+- or: match1 LT 1 OR match2 EQ "true" or match3 EQ true
+- or-single-match: match1 LT 1 OR match2 EQ "notamatch"
+
+## Workload Parameters
+
+- `docscount` - the number of documents to write during rampup (default: `10_000_000`)
+- `docpadding` - the number of fields to add to each document; useful for writing larger documents. A value of e.g. `5` would make each document have 20 leaf values, instead of 15. (default: `0`)
+- `match-ratio` - a value between 0 and 1 detailing what ratio of the documents written should match the search parameters. If match-ratio is e.g. `0.1` then approximately one-tenth of the documents will have `match1`, `match2`, and `match3` values that are `0`, `"true"`, and `true`, respectively. (default: `0.01`)
+- `fields` - the URL-encoded value for `fields` that you would send to the Docs API. This restricts the fields returned during benchmarking.
+
+

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -8,7 +8,7 @@ description: |
 
 scenarios:
   schema:                run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-  rampup-write:          run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-write:          run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
   rampup-read:           run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main:                  run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   main-eq:               run driver=http tags==phase:main,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
@@ -40,9 +40,9 @@ bindings:
   lng: Hash() -> long; Uniform(-180d, 180d)
   friend_id: Add(-1); ToHashedUUID(); ToString() -> String
 
-  match1: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return 0; } return (int)(Math.random() * 10000 + 1000);') -> long
-  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
-  additional_fields: Expr('str="";for (int i=0; i < TEMPLATE(docsize,15) - 15; i++) { if (str == "") { str = "," }; str+="\"value"+i+"\":0"; if (i < TEMPLATE(docsize,15) - 16) {str += ","}} return str;') -> String
+  match1: Identity(); CoinFunc(<<match-ratio>>, FixedValue(0), FixedValue(1000))
+  match2: Identity(); CoinFunc(<<match-ratio>>, FixedValue("true"), FixedValue("false"))
+  additional_fields: ListSizedStepped(<<docpadding:0>>,Template("\"{}\":{}",Identity(),Identity())); ToString(); ReplaceAll('\[\"', ',\"'); ReplaceAll('\[', ''); ReplaceAll('\]', '') -> String
 
 blocks:
   - tags:
@@ -153,8 +153,8 @@ blocks:
       phase:  rampup-read
       filter: and
     statements:
-      # where={"match1":{"$lt":1},"match2":{"$eq":"match"}}
-      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match1":{"$lt":1},"match2":{"$eq":"true"}}
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -167,8 +167,8 @@ blocks:
       phase:  rampup-read
       filter: or
     statements:
-      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"match"}},{"match3":{"$eq":true}}]}
-      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"true"}},{"match3":{"$eq":true}}]}
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -223,8 +223,8 @@ blocks:
       phase:  main
       filter: and
     statements:
-      # where={"match1":{"$lt":1},"match2":{"$eq":"match"}}
-      - main-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match1":{"$lt":1},"match2":{"$eq":"true"}}
+      - main-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -237,8 +237,8 @@ blocks:
       phase:  main
       filter: or
     statements:
-      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"match"}},{"match3":{"$eq":true}}]}
-      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"true"}},{"match3":{"$eq":true}}]}
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -9,11 +9,12 @@ description: |
 scenarios:
   schema:         run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
   rampup-write:   run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-  rampup-read:    run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) threads=<<threads:auto>> errors=timer,warn
-  read-eq:        run driver=http tags==phase:main,type:write cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
-  # read-lt:  run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
-  # read-and: run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
-  # read-or:  run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
+  rampup-read:    run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main:           run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-eq:        run driver=http tags==phase:main,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-lt:        run driver=http tags==phase:main,filter:lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-and:       run driver=http tags==phase:main,filter:and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-or:        run driver=http tags==phase:main,filter:or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
@@ -40,7 +41,7 @@ bindings:
   friend_id: Add(-1); ToHashedUUID(); ToString() -> String
 
   match1: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return 0; } return (int)(Math.random() * 10000 + 1000);') -> long
-  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "match" } return "no match";') -> String
+  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "true" } return "false";') -> String
   additional_fields: Expr('str="";for (int i=0; i < TEMPLATE(docsize,15) - 15; i++) { if (str == "") { str = "," }; str+="\"value"+i+"\":0"; if (i < TEMPLATE(docsize,15) - 16) {str += ","}} return str;') -> String
 
 blocks:
@@ -113,7 +114,8 @@ blocks:
             ],
             "debt":         null,
             "match1":       {match1},
-            "match2":       "{match2}"
+            "match2":       "{match2}",
+            "match3":       {match2},
             {additional_fields}
           }
         tags:
@@ -124,7 +126,7 @@ blocks:
       phase: rampup-read
       filter: eq
     statements:
-      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D&page-size=<<page-size,3>>
+      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -137,7 +139,7 @@ blocks:
       phase: rampup-read
       filter: lt
     statements:
-      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24eq%22%3A1%7D%7D&page-size=<<page-size,3>>
+      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -150,7 +152,7 @@ blocks:
       phase:  rampup-read
       filter: and
     statements:
-      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D&page-size=<<page-size,3>>
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -163,10 +165,62 @@ blocks:
       phase:  rampup-read
       filter: or
     statements:
-      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%5D%7D&page-size=<<page-size,3>>
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
         Content-Type: "application/json"
         tags:
           name: rampup-or
+
+  - name: main-eq
+    tags:
+      phase: main
+      filter: eq
+    statements:
+      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-eq
+  
+  - name: main-lt
+    tags:
+      phase: main
+      filter: lt
+    statements:
+      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-lt
+
+  - name: main-and
+    tags:
+      phase:  main
+      filter: and
+    statements:
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-and
+
+  - name: main-or
+    tags:
+      phase:  main
+      filter: or
+    statements:
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-or

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -126,7 +126,7 @@ blocks:
       filter: eq
     statements:
       # where={"match3":{"$eq":true}}
-      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match3":{"$eq":true}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -140,7 +140,7 @@ blocks:
       filter: lt
     statements:
       # where={"match1":{"$lt":1}}
-      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$lt":1}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -154,7 +154,7 @@ blocks:
       filter: and
     statements:
       # where={"match1":{"$lt":1},"match2":{"$eq":"true"}}
-      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$lt":1},"match2":{"$eq":"true"}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -168,7 +168,7 @@ blocks:
       filter: or
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}
-      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -182,7 +182,7 @@ blocks:
       filter: or-single-match
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}
-      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22notamatch%22%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -196,7 +196,7 @@ blocks:
       filter: eq
     statements:
       # where={"match3":{"$eq":true}}
-      - main-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match3":{"$eq":true}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -210,7 +210,7 @@ blocks:
       filter: lt
     statements:
       # where={"match1":{"$lt":1}}
-      - main-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$lt":1}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -224,7 +224,7 @@ blocks:
       filter: and
     statements:
       # where={"match1":{"$lt":1},"match2":{"$eq":"true"}}
-      - main-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"match1":{"$lt":1},"match2":{"$eq":"true"}}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -238,7 +238,7 @@ blocks:
       filter: or
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}
-      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -252,7 +252,7 @@ blocks:
       filter: or-single-match
     statements:
       # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}
-      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22notamatch%22%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=URLENCODE[[{"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}]]&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -1,0 +1,172 @@
+# nb -v run driver=http yaml=http-docsapi-search-basic tags=phase:schema stargate_host=my_stargate_host auth_token=$AUTH_TOKEN
+
+description: |
+  This workload emulates basic search operations for the Stargate Documents API.
+  During the rampup phase, it generates documents, writes them to a table, and then warms up the search paths.
+  During the main phase it performs various basic search filters and times their execution.
+  Note that stargate_port should reflect the port where the Docs API is exposed (defaults to 8082).
+
+scenarios:
+  schema:         run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
+  rampup-write:   run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-read:    run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) threads=<<threads:auto>> errors=timer,warn
+  read-eq:        run driver=http tags==phase:main,type:write cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
+  # read-lt:  run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
+  # read-and: run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
+  # read-or:  run driver=http tags==phase:main,type:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) match-ratio=TEMPLATE(match-ratio,0.01) fields=TEMPLATE(fields, UNSET) threads=auto errors=timer,warn
+
+bindings:
+  # To enable an optional weighted set of hosts in place of a load balancer
+  # Examples
+  #   single host: stargate_host=host1
+  #   multiple hosts: stargate_host=host1,host2,host3
+  #   multiple weighted hosts: stargate_host=host1:3,host2:7
+  weighted_hosts: WeightedStrings('<<stargate_host:stargate>>')
+  # http request id
+  request_id: ToHashedUUID(); ToString();
+
+  seq_key: Mod(<<docscount:10000000>>); ToString() -> String
+  random_key: Uniform(0,<<docscount:10000000>>); ToString() -> String
+
+  user_id: ToHashedUUID(); ToString() -> String
+  created_on: Uniform(1262304000,1577836800) -> long
+  gender: WeightedStrings('M:10;F:10;O:1')
+  full_name: FullNames()
+  married: ModuloToBoolean()
+  city: Cities()
+  country_code: CountryCodes()
+  lat: Uniform(-180d, 180d)
+  lng: Hash() -> long; Uniform(-180d, 180d)
+  friend_id: Add(-1); ToHashedUUID(); ToString() -> String
+
+  match1: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return 0; } return (int)(Math.random() * 10000 + 1000);') -> long
+  match2: Expr('if (cycle % (int)(1 / <<match-ratio>>) == 0) { return "match" } return "no match";') -> String
+  additional_fields: Expr('str="";for (int i=0; i < TEMPLATE(docsize,15) - 15; i++) { if (str == "") { str = "," }; str+="\"value"+i+"\":0"; if (i < TEMPLATE(docsize,15) - 16) {str += ","}} return str;') -> String
+
+blocks:
+  - tags:
+      phase: schema
+    statements:
+      - create-keyspace: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/schemas/keyspaces
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<keyspace:docs_search_basic>>",
+              "replicas": <<rf:1>>
+          }
+        tags:
+          name: create-keyspace
+
+      - delete-docs-collection: DELETE <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        tags:
+          name: delete-table
+        ok-status: "[2-4][0-9][0-9]"
+
+      - create-docs-collection: POST <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+              "name": "<<table:docs_collection>>"
+          }
+        tags:
+          name: create-table
+  
+  - name: rampup-write
+    tags:
+      phase: rampup-write
+    statements:
+      - rampup-insert: PUT <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>/{seq_key}
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        body: |
+          {
+            "user_id":      "{user_id}",
+            "created_on":   {created_on},
+            "gender":       "{gender}",
+            "full_name":    "{full_name}",
+            "married":      {married},
+            "address": {
+              "primary": {
+                  "city":   "{city}",
+                  "cc":     "{country_code}"
+              },
+              "secondary":  {}
+            },
+            "coordinates": [
+                            {lat},
+                            {lng}
+            ],
+            "children":     [],
+            "friends": [
+                            "{friend_id}"
+            ],
+            "debt":         null,
+            "match1":       {match1},
+            "match2":       "{match2}"
+            {additional_fields}
+          }
+        tags:
+          name: rampup-insert
+  
+  - name: rampup-eq
+    tags:
+      phase: rampup-read
+      filter: eq
+    statements:
+      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24eq%22%3A0%7D%7D&page-size=<<page-size,3>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-eq
+  
+  - name: rampup-lt
+    tags:
+      phase: rampup-read
+      filter: lt
+    statements:
+      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24eq%22%3A1%7D%7D&page-size=<<page-size,3>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-lt
+
+  - name: rampup-and
+    tags:
+      phase:  rampup-read
+      filter: and
+    statements:
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D&page-size=<<page-size,3>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-and
+
+  - name: rampup-or
+    tags:
+      phase:  rampup-read
+      filter: or
+    statements:
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%5D%7D&page-size=<<page-size,3>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-or

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -7,14 +7,15 @@ description: |
   Note that stargate_port should reflect the port where the Docs API is exposed (defaults to 8082).
 
 scenarios:
-  schema:         run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-  rampup-write:   run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-  rampup-read:    run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main:           run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main-eq:        run driver=http tags==phase:main,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main-lt:        run driver=http tags==phase:main,filter:lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main-and:       run driver=http tags==phase:main,filter:and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main-or:        run driver=http tags==phase:main,filter:or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  schema:                run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
+  rampup-write:          run driver=http tags==phase:rampup-write cycles===TEMPLATE(docscount,10000000) docsize=TEMPLATE(docsize,15) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+  rampup-read:           run driver=http tags==phase:rampup-read cycles===TEMPLATE(rampup-cycles, 10000000) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main:                  run driver=http tags==phase:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-eq:               run driver=http tags==phase:main,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-lt:               run driver=http tags==phase:main,filter:lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-and:              run driver=http tags==phase:main,filter:and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-or:               run driver=http tags==phase:main,filter:or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  main-or-single-match:  run driver=http tags==phase:main,filter:or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer
@@ -31,7 +32,6 @@ bindings:
 
   user_id: ToHashedUUID(); ToString() -> String
   created_on: Uniform(1262304000,1577836800) -> long
-  gender: WeightedStrings('M:10;F:10;O:1')
   full_name: FullNames()
   married: ModuloToBoolean()
   city: Cities()
@@ -94,7 +94,6 @@ blocks:
           {
             "user_id":      "{user_id}",
             "created_on":   {created_on},
-            "gender":       "{gender}",
             "full_name":    "{full_name}",
             "married":      {married},
             "address": {
@@ -115,7 +114,7 @@ blocks:
             "debt":         null,
             "match1":       {match1},
             "match2":       "{match2}",
-            "match3":       {match2},
+            "match3":       {match2}
             {additional_fields}
           }
         tags:
@@ -126,6 +125,7 @@ blocks:
       phase: rampup-read
       filter: eq
     statements:
+      # where={"match3":{"$eq":true}}
       - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -139,6 +139,7 @@ blocks:
       phase: rampup-read
       filter: lt
     statements:
+      # where={"match1":{"$lt":1}}
       - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -152,7 +153,8 @@ blocks:
       phase:  rampup-read
       filter: and
     statements:
-      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match1":{"$lt":1},"match2":{"$eq":"match"}}
+      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -165,6 +167,7 @@ blocks:
       phase:  rampup-read
       filter: or
     statements:
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"match"}},{"match3":{"$eq":true}}]}
       - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
@@ -173,12 +176,27 @@ blocks:
         tags:
           name: rampup-or
 
+  - name: rampup-or-single-match
+    tags:
+      phase:  rampup
+      filter: or-single-match
+    statements:
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22notamatch%22%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: rampup-or-single-match
+
   - name: main-eq
     tags:
       phase: main
       filter: eq
     statements:
-      - rampup-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match3":{"$eq":true}}
+      - main-eq: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -191,7 +209,8 @@ blocks:
       phase: main
       filter: lt
     statements:
-      - rampup-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match1":{"$lt":1}}
+      - main-lt: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -204,7 +223,8 @@ blocks:
       phase:  main
       filter: and
     statements:
-      - rampup-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"match1":{"$lt":1},"match2":{"$eq":"match"}}
+      - main-and: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%2C%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%2C%22match3%22%3A%7B%22%24eq%22%3A%20true%7D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -217,10 +237,25 @@ blocks:
       phase:  main
       filter: or
     statements:
-      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"match"}},{"match3":{"$eq":true}}]}
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22match%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
         Content-Type: "application/json"
         tags:
           name: main-or
+
+  - name: main-or-single-match
+    tags:
+      phase:  main
+      filter: or-single-match
+    statements:
+      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"notamatch"}}]}
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22notamatch%22%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+        Accept: "application/json"
+        X-Cassandra-Request-Id: "{request_id}"
+        X-Cassandra-Token: "<<auth_token:my_auth_token>>"
+        Content-Type: "application/json"
+        tags:
+          name: main-or-single-match

--- a/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
+++ b/driver-http/src/main/resources/activities/documents-api/http-docsapi-search-basic.yaml
@@ -167,8 +167,8 @@ blocks:
       phase:  rampup-read
       filter: or
     statements:
-      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"true"}},{"match3":{"$eq":true}}]}
-      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}
+      - rampup-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"
@@ -237,8 +237,8 @@ blocks:
       phase:  main
       filter: or
     statements:
-      # where={"$or":[{"match1":{"$lt":1}},{"match2":{"$eq":"true"}},{"match3":{"$eq":true}}]}
-      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match2%22%3A%7B%22%24eq%22%3A%22true%22%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
+      # where={"$or":[{"match1":{"$lt":1}},{"match3":{"$eq":true}}]}
+      - main-or: GET <<protocol:http>>://{weighted_hosts}:<<stargate_port:8082>><<path_prefix:>>/v2/namespaces/<<keyspace:docs_search_basic>>/collections/<<table:docs_collection>>?where=%7B%22%24or%22%3A%5B%7B%22match1%22%3A%7B%22%24lt%22%3A1%7D%7D%2C%7B%22match3%22%3A%7B%22%24eq%22%3Atrue%7D%7D%5D%7D&page-size=<<page-size,3>>&fields=<<fields,%5b%5d>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "<<auth_token:my_auth_token>>"


### PR DESCRIPTION
This adds two new workloads in the http-driver's resources for testing with the Stargate Documents API.

The tests specifically test the search functionality in the Docs API. The two workloads are for "basic" functionality (i.e. filters that are supported by cassandra, using a single AND or OR), and "advanced" functionality (i.e. filters that are unsupported in various combinations, with more complex boolean logic)

For each of these tests, one can define the following special parameters for the write phase:

`match-ratio` (between 0 and 1): defines how many documents to write that match the filters during the write phase (a value of 0.1 for example would mean that 1 of every 10 documents should match the search filters)

`docpadding` (defaults to 0): defines how large each document should be; adds values to each document to make them larger.

`docscount` (defaults to 10M): defines how many documents should be written during the write phase

And the following special parameters for the read phase:

`fields` (defaults to all): which fields to select

`page-size` (defaults to 3, max 20): how many documents to limit the search to

