### PR TITLE
Pulsar: Workaround an ordering bug in the Pulsar client

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -2,6 +2,7 @@ package io.nosqlbench.driver.pulsar.ops;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -115,11 +116,11 @@ public class PulsarConsumerOp implements PulsarOp {
                     message = consumer.receive();
                 }
                 else {
-                    // we cannot use Consumer#receive(timeout, timeunit) due to
-                    // https://github.com/apache/pulsar/issues/9921
                     message = consumer
-                        .receiveAsync()
-                        .get(timeoutSeconds, TimeUnit.SECONDS);
+                        .receive(timeoutSeconds, TimeUnit.SECONDS);
+                    if (message == null) {
+                        throw new TimeoutException("Did not receive a message within "+timeoutSeconds+" seconds");
+                    }
                 }
 
                 if (logger.isDebugEnabled()) {


### PR DESCRIPTION
- see https://github.com/apache/pulsar/pull/12456 for details about the Pulsar client ordering bug.
  - the bug applies to the use of receiveAsync and the workaround
    is to avoid the use of receiveAsync until the fix is included in the client
- receiveAsync was introduced previously to workaround the bug https://github.com/apache/pulsar/issues/9921
  - that issue isn't critical