### PR TITLE
fix http driver default scenarios

### DIFF
--- a/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/baselines/http-rest-keyvalue.yaml
@@ -7,7 +7,7 @@ description: |
 
 scenarios:
   default:
-    schema: run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    schema: run driver=http tags==phase:schema threads==1 cycles==UNDEF
     rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
     main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:

--- a/driver-http/src/main/resources/activities/baselines/http-rest-tabular.yaml
+++ b/driver-http/src/main/resources/activities/baselines/http-rest-tabular.yaml
@@ -8,7 +8,7 @@ description: |
 
 scenarios:
   default:
-    - run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
     - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
     - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:

--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-keyvalue.yaml
@@ -8,7 +8,7 @@ description: |
 
 scenarios:
   default:
-    schema: run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    schema: run driver=http tags==phase:schema threads==1 cycles==UNDEF
     rampup: run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
     main: run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:

--- a/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-tabular.yaml
+++ b/driver-http/src/main/resources/activities/graphql-cql-first/http-graphql-cql-tabular.yaml
@@ -9,7 +9,7 @@ description: |
 
 scenarios:
   default:
-    - run driver=cql tags==phase:schema threads==1 cycles==UNDEF
+    - run driver=http tags==phase:schema threads==1 cycles==UNDEF
     - run driver=http tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
     - run driver=http tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 bindings:


### PR DESCRIPTION
in https://github.com/nosqlbench/nosqlbench/pull/306 we seem to have forgotten to update the default scenrios accordingly

(schemas are now created by http POST)

wondering: 
could the build add some validation of these values to prevent similar errors in the future?

could statements have more static checks around driver compatiblity?
for example some statement definitions could require a driver of the "http" family... others from the "cql" family.
As is you get a weird looking runtime error if specifying the wrong driver i think.