### PR TITLE
Update mongo-driver-sync to 4.4.0

### DIFF
--- a/driver-mongodb/pom.xml
+++ b/driver-mongodb/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.0.3</version>
+            <version>4.4.0</version>
         </dependency>
 
     </dependencies>

--- a/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataBaseListener.java
+++ b/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataBaseListener.java
@@ -1,4 +1,4 @@
-// Generated from VirtData.g4 by ANTLR 4.8
+// Generated from VirtData.g4 by ANTLR 4.9.2
 package io.nosqlbench.virtdata.lang.generated;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataLexer.java
+++ b/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataLexer.java
@@ -1,4 +1,4 @@
-// Generated from VirtData.g4 by ANTLR 4.8
+// Generated from VirtData.g4 by ANTLR 4.9.2
 package io.nosqlbench.virtdata.lang.generated;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;
@@ -11,7 +11,7 @@ import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class VirtDataLexer extends Lexer {
-	static { RuntimeMetaData.checkVersion("4.8", RuntimeMetaData.VERSION); }
+	static { RuntimeMetaData.checkVersion("4.9.2", RuntimeMetaData.VERSION); }
 
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =

--- a/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataListener.java
+++ b/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataListener.java
@@ -1,4 +1,4 @@
-// Generated from VirtData.g4 by ANTLR 4.8
+// Generated from VirtData.g4 by ANTLR 4.9.2
 package io.nosqlbench.virtdata.lang.generated;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataParser.java
+++ b/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/generated/VirtDataParser.java
@@ -1,4 +1,4 @@
-// Generated from VirtData.g4 by ANTLR 4.8
+// Generated from VirtData.g4 by ANTLR 4.9.2
 package io.nosqlbench.virtdata.lang.generated;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class VirtDataParser extends Parser {
-	static { RuntimeMetaData.checkVersion("4.8", RuntimeMetaData.VERSION); }
+	static { RuntimeMetaData.checkVersion("4.9.2", RuntimeMetaData.VERSION); }
 
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =


### PR DESCRIPTION
Resolves https://github.com/nosqlbench/nosqlbench/issues/388

After bumping version of `mongo-driver-sync` to 4.4.0 (latest), I can run workloads against a mongoDB atlas instance. I've tested that this change works with the Mongo workloads that I've added in the past, and tests pass.