### PR TITLE
Pulsar: support Schema.AUTO_CONSUME() and support KeyValue for RTT tracking feature

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -253,9 +253,11 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
             pulsarSchema = PulsarActivityUtil.getAvroSchema(schemaType, schemaDefStr);
         } else if (PulsarActivityUtil.isPrimitiveSchemaTypeStr(schemaType)) {
             pulsarSchema = PulsarActivityUtil.getPrimitiveTypeSchema((schemaType));
+        } else if (PulsarActivityUtil.isAutoConsumeSchemaTypeStr(schemaType)) {
+            pulsarSchema = Schema.AUTO_CONSUME();
         } else {
             throw new RuntimeException("Unsupported schema type string: " + schemaType + "; " +
-                "Only primitive type and Avro type are supported at the moment!");
+                "Only primitive type, Avro type and AUTO_CONSUME are supported at the moment!");
         }
     }
 

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -239,6 +239,7 @@ public class PulsarConsumerOp implements PulsarOp {
                             field = keyPart.getField(payloadRttTrackingField);
                         } catch (AvroRuntimeException err) {
                             // field is not in the key
+                            logger.error("Cannot find "+payloadRttTrackingField+" in key " + keyPart + ": " + err);
                         }
                     }
                     // look into the Value
@@ -248,7 +249,11 @@ public class PulsarConsumerOp implements PulsarOp {
                             field = valuePart.getField(payloadRttTrackingField);
                         } catch (AvroRuntimeException err) {
                             // field is not in the value
+                            logger.error("Cannot find "+payloadRttTrackingField+" in value " + valuePart + ": " + err);
                         }
+                    }
+                    if (field == null) {
+                        throw new RuntimeException("Cannot find field " + payloadRttTrackingField + " in " + keyValue.getKey() + " and " + keyValue.getValue());
                     }
                 } else {
                     field = pulsarGenericRecord.getField(payloadRttTrackingField);
@@ -260,6 +265,8 @@ public class PulsarConsumerOp implements PulsarOp {
                     } else {
                         extractedSendTime = Long.valueOf(field.toString());
                     }
+                } else {
+                    logger.error("Cannot find " + payloadRttTrackingField + " in value " + pulsarGenericRecord);
                 }
                 done = true;
             }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -25,7 +25,8 @@ import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.schema.KeyValue;
-import org.apache.pulsar.common.schema.SchemaType;
+// this is from the Shaded version of Avro inside the Pulsar client jar
+import org.apache.pulsar.shade.org.apache.avro.AvroRuntimeException;
 
 public class PulsarConsumerOp implements PulsarOp {
 
@@ -234,12 +235,20 @@ public class PulsarConsumerOp implements PulsarOp {
                     // look into the Key
                     if (keyValue.getKey() instanceof GenericRecord) {
                         GenericRecord keyPart = (GenericRecord) keyValue.getKey();
-                        field = keyPart.getField(payloadRttTrackingField);
+                        try {
+                            field = keyPart.getField(payloadRttTrackingField);
+                        } catch (AvroRuntimeException err) {
+                            // field is not in the key
+                        }
                     }
                     // look into the Value
                     if (keyValue.getValue() instanceof GenericRecord && field == null) {
                         GenericRecord valuePart = (GenericRecord) keyValue.getValue();
-                        field = valuePart.getField(payloadRttTrackingField);
+                        try {
+                            field = valuePart.getField(payloadRttTrackingField);
+                        } catch (AvroRuntimeException err) {
+                            // field is not in the value
+                        }
                     }
                 } else {
                     field = pulsarGenericRecord.getField(payloadRttTrackingField);

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -239,7 +239,7 @@ public class PulsarConsumerOp implements PulsarOp {
                             field = keyPart.getField(payloadRttTrackingField);
                         } catch (AvroRuntimeException err) {
                             // field is not in the key
-                            logger.error("Cannot find "+payloadRttTrackingField+" in key " + keyPart + ": " + err);
+                            logger.error("Cannot find {} in key {}: {}", payloadRttTrackingField, keyPart, err + "");
                         }
                     }
                     // look into the Value
@@ -249,11 +249,11 @@ public class PulsarConsumerOp implements PulsarOp {
                             field = valuePart.getField(payloadRttTrackingField);
                         } catch (AvroRuntimeException err) {
                             // field is not in the value
-                            logger.error("Cannot find "+payloadRttTrackingField+" in value " + valuePart + ": " + err);
+                            logger.error("Cannot find {} in value {}: {}", payloadRttTrackingField, valuePart, err + "");
                         }
                     }
                     if (field == null) {
-                        throw new RuntimeException("Cannot find field " + payloadRttTrackingField + " in " + keyValue.getKey() + " and " + keyValue.getValue());
+                        throw new RuntimeException("Cannot find field {}" + payloadRttTrackingField + " in " + keyValue.getKey() + " and " + keyValue.getValue());
                     }
                 } else {
                     field = pulsarGenericRecord.getField(payloadRttTrackingField);
@@ -266,7 +266,7 @@ public class PulsarConsumerOp implements PulsarOp {
                         extractedSendTime = Long.valueOf(field.toString());
                     }
                 } else {
-                    logger.error("Cannot find " + payloadRttTrackingField + " in value " + pulsarGenericRecord);
+                    logger.error("Cannot find {} in value {}", payloadRttTrackingField, pulsarGenericRecord);
                 }
                 done = true;
             }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -451,6 +451,10 @@ public class PulsarActivityUtil {
     public static boolean isAvroSchemaTypeStr(String typeStr) {
         return typeStr.equalsIgnoreCase("AVRO");
     }
+    // automatic decode the type from the Registry
+    public static boolean isAutoConsumeSchemaTypeStr(String typeStr) {
+        return typeStr.equalsIgnoreCase("AUTO_CONSUME");
+    }
     public static Schema<?> getAvroSchema(String typeStr, String definitionStr) {
         String schemaDefinitionStr = definitionStr;
         String filePrefix = "file://";


### PR DESCRIPTION
Modifications:
- support schema.type=AUTO_CONSUME
- unwrap the "value" inside the KeyValue structure for the RTT tracking