### PR TITLE
Pulsar: report latency in ns for Payload RRT and allow to connect with non-admin privileges

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
@@ -76,9 +76,9 @@ public class PulsarSpace {
             CollectionUtils.addAll(pulsarClusterMetadata, stringList.listIterator());
 
         } catch (PulsarAdminException e) {
-            String errMsg = "Fail to create PulsarClient from global configuration: " + e.getMessage();
-            logger.error(errMsg);
-            throw new RuntimeException(errMsg);
+            // this is okay if you are connecting with a token that does not have access to the
+            // system configuration
+            logger.info("Could not get list of Pulsar Clusters from global configuration: " + e.getMessage());
         }
     }
 

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarConsumerOp.java
@@ -279,7 +279,9 @@ public class PulsarConsumerOp implements PulsarOp {
                 }
             }
             if (extractedSendTime != null) {
-                long delta = System.currentTimeMillis() - extractedSendTime;
+                // fallout expects latencies in "ns" and not in "ms"
+                long delta = TimeUnit.MILLISECONDS
+                    .toNanos(System.currentTimeMillis() - extractedSendTime);
                 payloadRttHistogram.update(delta);
             }
         }


### PR DESCRIPTION
Fallout expects latencies in "ns" and not in "ms".
This patch reports latency for payload_rtt measure in "ns"

I also added a fix to connect to Pulsar cluster with Tokens with low privileges