### PR TITLE
Issue #417: Pulsar: implement KeyValue schema for PulsarProducerOp

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
@@ -15,8 +15,8 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarBatchProducerMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarBatchProducerMapper.java
@@ -6,7 +6,6 @@ import io.nosqlbench.driver.pulsar.util.PulsarActivityUtil;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.pulsar.client.api.Producer;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarProducerOp.java
@@ -108,15 +108,13 @@ public class PulsarProducerOp implements PulsarOp {
         SchemaType schemaType = pulsarSchema.getSchemaInfo().getType();
         if (pulsarSchema instanceof KeyValueSchema) {
 
+            // {KEY IN JSON}||{VALUE IN JSON}
             int separator = msgPayload.indexOf("}||{");
             if (separator < 0) {
                 throw new IllegalArgumentException("KeyValue payload MUST be in form {KEY IN JSON}||{VALUE IN JSON} (with 2 pipes that separate the KEY part from the VALUE part)");
             }
             String keyInput = msgPayload.substring(0, separator + 1);
             String valueInput = msgPayload.substring(separator + 3);
-            logger.info("msgPayload: {}", msgPayload);
-            logger.info("keyInput: {}", keyInput);
-            logger.info("valueInput: {}", valueInput);
 
             KeyValueSchema keyValueSchema = (KeyValueSchema) pulsarSchema;
             org.apache.avro.Schema avroSchema = getAvroSchemaFromConfiguration();
@@ -259,7 +257,6 @@ public class PulsarProducerOp implements PulsarOp {
         // no need for synchronization, this is only a cache
         // in case of the race we will parse the string twice, not a big
         if (avroSchema == null) {
-            logger.info("getAvroSchemaFromConfiguration...{}", pulsarSchema);
             if (pulsarSchema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
                 KeyValueSchema kvSchema = (KeyValueSchema) pulsarSchema;
                 Schema valueSchema = kvSchema.getValueSchema();
@@ -270,7 +267,6 @@ public class PulsarProducerOp implements PulsarOp {
                 avroSchema = AvroUtil.GetSchema_ApacheAvro(avroDefStr);
             }
         }
-        logger.info("getAvroSchemaFromConfiguration...avroSchema {}", avroSchema);
         return avroSchema;
     }
 
@@ -287,7 +283,6 @@ public class PulsarProducerOp implements PulsarOp {
                 throw new RuntimeException("We are not using KEY_VALUE schema, so no Schema for the Key!");
             }
         }
-        logger.info("getKeyAvroSchemaFromConfiguration...avroSchema {}", avroKeySchema);
         return avroKeySchema;
     }
 }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarReaderMapper.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/PulsarReaderMapper.java
@@ -4,7 +4,6 @@ import io.nosqlbench.driver.pulsar.PulsarActivity;
 import io.nosqlbench.driver.pulsar.PulsarSpace;
 import io.nosqlbench.engine.api.templating.CommandTemplate;
 import org.apache.pulsar.client.api.Reader;
-import org.apache.pulsar.client.api.Schema;
 
 import java.util.function.LongFunction;
 

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/AvroUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/AvroUtil.java
@@ -90,6 +90,10 @@ public class AvroUtil {
     // Get a Pulsar Avro record (GenericRecord) from a JSON string that matches a specific Pulsar Avro schema
     public static GenericRecord GetGenericRecord_PulsarAvro(GenericAvroSchema genericAvroSchema, String avroSchemDefStr, String jsonData) {
         org.apache.avro.Schema avroSchema = GetSchema_ApacheAvro(avroSchemDefStr);
+        return GetGenericRecord_PulsarAvro(genericAvroSchema, avroSchema, jsonData);
+    }
+
+    public static GenericRecord GetGenericRecord_PulsarAvro(GenericAvroSchema genericAvroSchema, org.apache.avro.Schema avroSchema, String jsonData) {
         org.apache.avro.generic.GenericRecord apacheAvroRecord = GetGenericRecord_ApacheAvro(avroSchema, jsonData);
         return GetGenericRecord_PulsarAvro(genericAvroSchema, apacheAvroRecord);
     }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -451,6 +451,10 @@ public class PulsarActivityUtil {
     public static boolean isAvroSchemaTypeStr(String typeStr) {
         return typeStr.equalsIgnoreCase("AVRO");
     }
+    public static boolean isKeyValueTypeStr(String typeStr) {
+        return typeStr.equalsIgnoreCase("KEY_VALUE");
+    }
+
     // automatic decode the type from the Registry
     public static boolean isAutoConsumeSchemaTypeStr(String typeStr) {
         return typeStr.equalsIgnoreCase("AUTO_CONSUME");


### PR DESCRIPTION
New features:
- in pulsar.yaml you can configure:
```
schema.type=AVRO
schema.definition=schema-for-value.avro
schema.key.type=AVRO
schema.key.definition=schema-for-key.avro
schema.keyvalue.encodingtype=SEPARATED (or INLINE)
```


In that case you can format your payload in JSON, use `||` to separate the KEY from the VALUE

```
description: |
  Test workload for new pulsar driver.

bindings:
  mykey: NumberNameToString();
  payload: AlphaNumericString(100);

blocks:
  - name: producer-block
    tags:
      phase: producer
      optype: msg-send
    statements:
      - name: producer-stuff
        optype: msg-send          
        topic_uri: "persistent://public/default/test"
        async_api: "false"
        use_transaction: "false"
        msg_value: "{\"key\":\"{mykey}\"}||{\"value\":\"{payload}\"}"
```

This is a 100% backward compatible change

Implements #417