### PR TITLE
Pulsar Driver: remove debug log that breaks Schema.AUTO_CONSUME() usage

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarActivity.java
@@ -277,7 +277,6 @@ public class PulsarActivity extends SimpleActivity implements ActivityDefObserve
             throw new RuntimeException("Unsupported schema type string: " + schemaType + "; " +
                 "Only primitive type, Avro type and AUTO_CONSUME are supported at the moment!");
         }
-        logger.info("Generated schema from {}={} {}={}: {}", schemaTypeConfEntry, value, schemaDefinitionConfEntry, schemaDefinition, result.getSchemaInfo().getSchemaDefinition());
         return result;
     }
 


### PR DESCRIPTION
This patches remove a log line (leftover of my previous patch, I apologise) that breaks users using Schema.AUTO_CONSUME().

This happens because AUTO_CONSUME() is a special "Schema" in Pulsar that downloads the schema from the SchemaRegistry and when we are logging the line I am dropping in this patch getSchemaInfo() is null because the schema has not been downloaded yet. 

This is the stacktrace of the error:

> write_ratio=10 table=cdctest rate=30000,1.3 username=cassandra password=cassandra secureconnectbundle=http://nginx.ingress:28080/secure-bundle-9dfd7719-b7c2-43b4-853e-f8604576d5db.zip -v --show-stacktraces --logs-dir /fallout-artifacts/nb-module-logs-benchmark_9dfd7719-b7c2-43b4-853e-f8604576d5db --log-histograms /fallout-artifacts/benchmark_9dfd7719-b7c2-43b4-853e-f8604576d5db.hdr::5s --log-histostats /fallout-artifacts/benchmark_9dfd7719-b7c2-43b4-853e-f8604576d5db.csv::5s start alias=pulsar_9dfd7719-b7c2-43b4-853e-f8604576d5db cycles=10000000  driver=pulsar config=/nosqlbench/pulsar.conf yaml=/nosqlbench/pulsar.yaml web_url=http://pulsar-proxy.default.svc.cluster.local:8080/ service_url=pulsar://pulsar-proxy.default.svc.cluster.local:6650 await benchmark_9dfd7719-b7c2-43b4-853e-f8604576d5db stop pulsar_9dfd7719-b7c2-43b4-853e-f8604576d5db'
> STDOUT (last 20 lines):
> 	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:147)
> 	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:93)
> 	at com.oracle.truffle.api.impl.DefaultCallTarget.callDirectOrIndirect(DefaultCallTarget.java:84)
> 	at com.oracle.truffle.api.impl.DefaultDirectCallNode.call(DefaultDirectCallNode.java:59)
> 	at com.oracle.truffle.js.lang.JavaScriptLanguage$1.execute(JavaScriptLanguage.java:214)
> 	at com.oracle.truffle.api.impl.DefaultCallTarget.callDirectOrIndirect(DefaultCallTarget.java:84)
> 	at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:99)
> 	at com.oracle.truffle.polyglot.PolyglotContextImpl.eval(PolyglotContextImpl.java:941)
> 	... 11 more
> Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.common.schema.SchemaInfo.getSchemaDefinition()" because the return value of "org.apache.pulsar.client.api.Schema.getSchemaInfo()" is null
> 	at io.nosqlbench.driver.pulsar.PulsarActivity.buldSchemaFromDefinition(PulsarActivity.java:280)
> 	at io.nosqlbench.driver.pulsar.PulsarActivity.createPulsarSchemaFromConf(PulsarActivity.java:248)
> 	at io.nosqlbench.driver.pulsar.PulsarActivity.initActivity(PulsarActivity.java:120)
> 	at io.nosqlbench.engine.core.lifecycle.ActivityExecutor.startActivity(ActivityExecutor.java:116)
> 	... 48 more
>    10907 ERROR [main] ERRORHANDLER cause (see stack trace for details):javax.script.ScriptException: java.lang.RuntimeException: Error initia