### PR TITLE
Pulsar: allow to configure 'ranges' for KEY_SHARED subscription type

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/PulsarSpace.java
@@ -396,7 +396,8 @@ public class PulsarSpace {
     public Consumer<?> getConsumer(String cycleTopicName,
                                    String cycleSubscriptionName,
                                    String cycleSubscriptionType,
-                                   String cycleConsumerName) {
+                                   String cycleConsumerName,
+                                   String cycleKeySharedSubscriptionRanges) {
         String subscriptionName = getEffectiveSubscriptionName(cycleSubscriptionName);
         SubscriptionType subscriptionType = getEffectiveSubscriptionType(cycleSubscriptionType);
         String consumerName = getEffectiveConsumerName(cycleConsumerName);
@@ -431,6 +432,16 @@ public class PulsarSpace {
                     topic(cycleTopicName).
                     subscriptionName(subscriptionName).
                     subscriptionType(subscriptionType);
+
+                if (subscriptionType == SubscriptionType.Key_Shared) {
+                    KeySharedPolicy keySharedPolicy = KeySharedPolicy.autoSplitHashRange();
+                    if (cycleKeySharedSubscriptionRanges != null && !cycleKeySharedSubscriptionRanges.isEmpty()) {
+                        Range[] ranges = parseRanges(cycleKeySharedSubscriptionRanges);
+                        logger.info("Configuring KeySharedPolicy#stickyHashRange with ranges {}", ranges);
+                        keySharedPolicy = KeySharedPolicy.stickyHashRange().ranges(ranges);
+                    }
+                    consumerBuilder.keySharedPolicy(keySharedPolicy);
+                }
 
                 if (!StringUtils.isBlank(consumerName)) {
                     consumerBuilder = consumerBuilder.consumerName(consumerName);
@@ -471,6 +482,30 @@ public class PulsarSpace {
 
         return consumer;
     }
+
+    private static Range[] parseRanges(String ranges) {
+        if (ranges == null || ranges.isEmpty()) {
+            return new Range[0];
+        }
+        String[] split = ranges.split(",");
+        Range[] result = new Range[split.length];
+        for (int i = 0; i < split.length; i++) {
+            String range = split[i];
+            int pos = range.indexOf("..");
+            if (pos <= 0) {
+                throw new IllegalArgumentException("Invalid range '" + range + "'");
+            }
+            try {
+                int start = Integer.parseInt(range.substring(0, pos));
+                int end = Integer.parseInt(range.substring(pos + 2));
+                result[i] = Range.of(start, end);
+            } catch (NumberFormatException err) {
+                throw new IllegalArgumentException("Invalid range '" + range + "'");
+            }
+        }
+        return result;
+    }
+
     //
     //////////////////////////////////////
     // Consumer Processing <-- end

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/ops/ReadyPulsarOp.java
@@ -322,6 +322,8 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
 
         LongFunction<String> consumer_name_func = lookupParameterFunc("consumer_name");
 
+        LongFunction<String> ranges_func = lookupParameterFunc("ranges", false, "");
+
         LongFunction<Supplier<Transaction>> transactionSupplierFunc =
             (l) -> clientSpace.getTransactionSupplier(); //TODO make it dependant on current cycle?
 
@@ -330,7 +332,8 @@ public class ReadyPulsarOp implements OpDispenser<PulsarOp> {
                 topic_uri_func.apply(l),
                 subscription_name_func.apply(l),
                 subscription_type_func.apply(l),
-                consumer_name_func.apply(l)
+                consumer_name_func.apply(l),
+                ranges_func.apply(l)
             );
 
         return new PulsarConsumerMapper(


### PR DESCRIPTION
## Modifications
Allow to configure a list of 'ranges' for the configuration of the KEY_SHARED subscription for the Pulsar Consumer.

You can configure ranges using this syntax:
ranges:0..30000,30001..65534

The validation for the values (that should be between 0 and 65534) is done by Pulsar on both the client side and on the server side (only the server may know if there aren't consumer with overlapping ranges, and it is useless to try to do complex validations on NB side)

See here for a brief description of the feature:
https://medium.com/@ankushkhanna1988/apache-pulsar-key-shared-mode-sticky-consistent-hashing-a4ee7133930a#:~:text=Consumer%201%20hash%20range%20%3D%200,hash%20range%20%3D%2049152%20to%2065535

Example YAML file:

```
description: |
  Test workload for new pulsar driver.

bindings:
  mykey: NumberNameToString();
  payload: AlphaNumericString(100);

blocks:
  - name: producer-block
    tags:
      phase: producer
      optype: msg-send
    statements:
      - name: producer-stuff
        optype: msg-send
        topic_uri: "persistent://public/default/test"
        async_api: "false"
        use_transaction: "false"
        msg_key: "{mykey}"
        msg_value: "{payload}"

  - name: consumer-first-half
    tags:
      phase: consumer
      half: first
    statements:
      - name: consumer-first-half
        optype: msg-consume
        topic_uri: "persistent://public/default/test"
        subscription_name: nb
        subscription_type: Key_Shared
        ranges: 0..30000
  - name: consumer-second-half
    tags:
      phase: consumer
      half: second
    statements:
      - name: consumer-second-half
        optype: msg-consume
        topic_uri: "persistent://public/default/test"
        subscription_name: nb
        subscription_type: Key_Shared
        ranges: 30001..65535
```

A command to run a producer and the two consumers reads like this:

```
java -jar nb/target/nb.jar -v \
     start alias=first driver=pulsar yaml=pulsar.yaml config=pulsar.conf tags=half:first cycles=1..4594 \
     start alias=second driver=pulsar yaml=pulsar.yaml config=pulsar.conf tags=half:second cycles=1..5406 \
     start alias=producer driver=pulsar yaml=pulsar.yaml config=pulsar.conf tags=phase:producer cycles=10000
```

The two ConsumeOp will receive exactly the expected numbers of messages (4594 and 5406) because the dispatching depends on the keys, that are generated using a deterministic function `NumberNameToString()`