### PR TITLE
Brought percentile sample points on a 0-100 scale (fixes issue #560)

### DIFF
--- a/nb-api/src/main/java/io/nosqlbench/engine/api/metrics/HistoStatsCSVWriter.java
+++ b/nb-api/src/main/java/io/nosqlbench/engine/api/metrics/HistoStatsCSVWriter.java
@@ -93,15 +93,15 @@ public class HistoStatsCSVWriter {
         csvLine.append(",").append(len);
         csvLine.append(",").append(h.getTotalCount());
         csvLine.append(",").append(h.getMinValue());
-        csvLine.append(",").append(h.getValueAtPercentile(0.25D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.50D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.75D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.90D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.95D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.98D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.99D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.999D));
-        csvLine.append(",").append(h.getValueAtPercentile(0.9999D));
+        csvLine.append(",").append(h.getValueAtPercentile(25.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(50.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(75.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(90.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(95.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(98.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(99.00D));
+        csvLine.append(",").append(h.getValueAtPercentile(99.90D));
+        csvLine.append(",").append(h.getValueAtPercentile(99.99D));
         csvLine.append(",").append(h.getMaxValue());
         writer.println(csvLine);
 


### PR DESCRIPTION
Rescaling the percentile values to a 0-100 scale fixes issue #560 (incorrect percentile values being printed in "histostats" output).

Tested by comparing the percentiles from histostats to the equivalent values as extracted from the full-HDR output measured in the same nb runs.