### PR TITLE
Pulsar: fix race in creating Pulsar Consumer and upgrade to Pulsar 2.8.3

### DIFF
--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <pulsar.version>2.8.2</pulsar.version>
+        <pulsar.version>2.8.3</pulsar.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Motivation**

If you start the Pulsar Driver, PulsarConsumerOp, with multiple threads you end up in creating multiple Consumers but then you are going to use only one of them.
This is a problem in case of Pulsar SHARED or KEY_SHARED subscriptions, because the zombie Consumer will pre-fetch messages that won't ever be processed, an so NB will never be able to fully consume a topic

**Changes**

- Use "computeIfAbsent"
- Upgrade Pulsar Client to 2.8.3 (not strictly needed)