### PR TITLE
Add a line detailing the various time units in the HDR from '--log-histograms'

### DIFF
--- a/nb-api/src/main/java/io/nosqlbench/engine/api/metrics/HistoIntervalLogger.java
+++ b/nb-api/src/main/java/io/nosqlbench/engine/api/metrics/HistoIntervalLogger.java
@@ -67,6 +67,10 @@ public class HistoIntervalLogger extends  CapabilityHook<HdrDeltaHistogramAttach
         return pattern.matcher(metricName).matches();
     }
 
+    private static final String HDR_UNITS_GUIDE = "UNITS: StartTimestamp = seconds since StartTime; "
+                                                + "Interval_Length = seconds, Interval_Max = milliseconds, "
+                                                + "values in the histogram = nanoseconds";
+
     /**
      * By convention, it is typical for the logging application
      * to use a comment to indicate the logging application at the head
@@ -81,6 +85,7 @@ public class HistoIntervalLogger extends  CapabilityHook<HdrDeltaHistogramAttach
             writer.outputLogFormatVersion();
             long currentTimeMillis = System.currentTimeMillis();
             writer.outputStartTime(currentTimeMillis);
+            writer.outputComment(HDR_UNITS_GUIDE);
             writer.setBaseTime(currentTimeMillis);
             writer.outputLegend();
         } catch (FileNotFoundException e) {


### PR DESCRIPTION
This PR addresses issue  #400 (various time units being used for different quantities in the HDR histogram files) by simply printing an additional (comment) line in the header of each HDR file being generated.

The line is:
```
#UNITS: StartTimestamp = seconds since StartTime; Interval_Length = seconds, Interval_Max = milliseconds, values in the histogram = nanoseconds
```
and appears right before the legend + values, as in:
```
#logging histograms for session scenario_20220512_154057_037
#[Histogram log format version 1.3]
#[StartTime: 1652362859.432 (seconds since epoch), Thu May 12 15:40:59 CEST 2022]
#UNITS: StartTimestamp = seconds since StartTime; Interval_Length = seconds, Interval_Max = milliseconds, values in the histogram = nanoseconds
"StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
Tag=cqlkeyvalue_default_main.result,31.841,8.163,2.970,HISTFAAAAVF42i [...]
```

The only possible caveat is that, should a nb user rely on skipping a certain fixed number of lines when consuming the HDR file, that process would break.