### PR TITLE
Minor fix for #584: `BUILDING.md` should say Java baseline is 17, not 12

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,7 +2,7 @@
 
 ## requirements
 
-You need Java 12 or newer to build NoSQLBench.
+You need Java 17 or newer to build NoSQLBench.
 
 # Building Locally
 


### PR DESCRIPTION
(default defined in `mvn-defaults/pom.xml` for maven compiler plugin)
