### PR TITLE
Fix indentation in baselines2/cql-keyvalue2.yaml for schema-astra block

### DIFF
--- a/adapter-cqld4/src/main/resources/activities/baselinesv2/cql-keyvalue2.yaml
+++ b/adapter-cqld4/src/main/resources/activities/baselinesv2/cql-keyvalue2.yaml
@@ -40,16 +40,16 @@ blocks:
          value text,
          PRIMARY KEY (key)
         );
-    schema-astra:
-      params:
-        prepared: false
-      statements:
-        create-table: |
-          create table if not exists TEMPLATE(keyspace,baselines).TEMPLATE(table,keyvalue) (
-          key text,
-           value text,
-           PRIMARY KEY (key)
-          );
+  schema-astra:
+    params:
+      prepared: false
+    statements:
+      create-table: |
+        create table if not exists TEMPLATE(keyspace,baselines).TEMPLATE(table,keyvalue) (
+        key text,
+         value text,
+         PRIMARY KEY (key)
+        );
   rampup:
     params:
       cl: TEMPLATE(write_cl,LOCAL_QUORUM)


### PR DESCRIPTION
Workload file cql-keyvalue2.yaml had an indentation too much for the block "schema-astra". That made the "block" not be treated like a block, so for instance a command such as `nb5 cql-keyvalue2 astra [...]` would fail immediately with error
```
javax.script.ScriptException: io.nosqlbench.nb.api.errors.BasicError: There were no active statements with tag filter 'block:schema-astra', since all 7 were filtered out.
```

Reducing the indentation of the block bringing it on par with the other blocks fixed the issue.
