### PR TITLE
Add "max_s4jop_time" and "track_msg_cnt" CLI options

### DIFF
--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/ReadyS4JOp.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/ReadyS4JOp.java
@@ -47,7 +47,7 @@ public class ReadyS4JOp implements OpDispenser<S4JOp> {
 
     public ReadyS4JOp(OpTemplate optpl, S4JSpaceCache s4JSpaceCache, S4JActivity s4JActivity) {
         this.optpl = optpl;
-        this.cmdTpl = new CommandTemplate(optpl);
+        this.cmdTpl = new CommandTemplate(this.optpl);
         this.s4JActivity = s4JActivity;
 
         String client_name = lookupStaticParameter("client", false, "default");
@@ -56,6 +56,7 @@ public class ReadyS4JOp implements OpDispenser<S4JOp> {
 
         // Initialize JMS connection and sessions
         this.s4JSpace.initializeS4JConnectionFactory(s4JActivity.getS4JConnInfo());
+        this.s4JActivity.setS4JActivityStartTimeMills(System.currentTimeMillis());
 
         this.s4JSpace.resetTotalOpResponseCnt();
 

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgBrowseMapper.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgBrowseMapper.java
@@ -26,16 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import javax.jms.*;
 import java.util.function.LongFunction;
 
-/**
- * This maps a set of specifier functions to a pulsar operation. The pulsar operation contains
- * enough state to define a pulsar operation such that it can be executed, measured, and possibly
- * retried if needed.
- *
- * This function doesn't act *as* the operation. It merely maps the construction logic into
- * a simple functional type, given the component functions.
- *
- * For additional parameterization, the command template is also provided.
- */
 public class S4JMsgBrowseMapper extends S4JOpMapper {
 
     private final LongFunction<String> msgSelectorStrFunc;
@@ -99,6 +89,7 @@ public class S4JMsgBrowseMapper extends S4JOpMapper {
         }
 
         return new S4JMsgBrowseOp(
+            value,
             s4JActivity,
             jmsContext,
             queue,

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgReadMapper.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgReadMapper.java
@@ -25,16 +25,6 @@ import io.nosqlbench.driver.jms.util.S4JJMSContextWrapper;
 import javax.jms.*;
 import java.util.function.LongFunction;
 
-/**
- * This maps a set of specifier functions to a pulsar operation. The pulsar operation contains
- * enough state to define a pulsar operation such that it can be executed, measured, and possibly
- * retried if needed.
- *
- * This function doesn't act *as* the operation. It merely maps the construction logic into
- * a simple functional type, given the component functions.
- *
- * For additional parameterization, the command template is also provided.
- */
 public class S4JMsgReadMapper extends S4JOpMapper {
 
     private final boolean durable;
@@ -124,10 +114,10 @@ public class S4JMsgReadMapper extends S4JOpMapper {
         if (readTimeout < 0) readTimeout = 0;
 
         return new S4JMsgReadOp(
+            value,
             s4JSpace,
             s4JActivity,
             jmsContext,
-            destination,
             asyncAPIBool,
             blockingMsgRecvBool,
             consumer,

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgSendMapper.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JMsgSendMapper.java
@@ -35,16 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.LongFunction;
 
-/**
- * This maps a set of specifier functions to a pulsar operation. The pulsar operation contains
- * enough state to define a pulsar operation such that it can be executed, measured, and possibly
- * retried if needed.
- *
- * This function doesn't act *as* the operation. It merely maps the construction logic into
- * a simple functional type, given the component functions.
- *
- * For additional parameterization, the command template is also provided.
- */
 public class S4JMsgSendMapper extends S4JOpMapper {
 
     private final static Logger logger = LogManager.getLogger(S4JMsgSendMapper.class);
@@ -317,7 +307,7 @@ public class S4JMsgSendMapper extends S4JOpMapper {
 
         JMSProducer producer;
         try {
-            producer = s4JSpace.getOrCreateJmsProducer(s4JJMSContextWrapper, destination, destType, asyncAPIBool);
+            producer = s4JSpace.getOrCreateJmsProducer(s4JJMSContextWrapper, asyncAPIBool);
         }
         catch (JMSException jmsException) {
             throw new S4JDriverUnexpectedException("Unable to create the JMS producer!");
@@ -370,6 +360,7 @@ public class S4JMsgSendMapper extends S4JOpMapper {
         }
 
         return new S4JMsgSendOp(
+            value,
             s4JSpace,
             s4JActivity,
             jmsContext,

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JTimeTrackOp.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/ops/S4JTimeTrackOp.java
@@ -21,6 +21,17 @@ package io.nosqlbench.driver.jms.ops;
  */
 public abstract class S4JTimeTrackOp implements S4JOp {
 
+    protected final long curNBCycleNum;
+    protected final long s4jOpStartTimeMills;
+    protected final long maxS4jOpDurationInSec;
+
+    public S4JTimeTrackOp(long curCycleNum, long s4jOpStartTimeMills, long maxS4jOpDurationInSec) {
+        this.curNBCycleNum = curCycleNum;
+        this.s4jOpStartTimeMills = s4jOpStartTimeMills;
+        this.maxS4jOpDurationInSec = maxS4jOpDurationInSec;
+        assert (this.maxS4jOpDurationInSec >= 0);
+    }
+
     public void run(Runnable timeTracker) {
         try {
             this.run();

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/util/S4JCompletionListener.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/util/S4JCompletionListener.java
@@ -1,0 +1,80 @@
+package io.nosqlbench.driver.jms.util;
+
+/*
+ * Copyright (c) 2022 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.nosqlbench.driver.jms.S4JActivity;
+import io.nosqlbench.driver.jms.S4JSpace;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.jms.*;
+
+/**
+ *  Used for async message production
+ */
+public class S4JCompletionListener implements CompletionListener {
+
+    private final static Logger logger = LogManager.getLogger(S4JSpace.class);
+
+    private final S4JSpace s4JSpace;
+    private final S4JActivity s4JActivity;
+
+    public S4JCompletionListener(S4JSpace s4JSpace) {
+        assert (s4JSpace != null);
+        this.s4JSpace = s4JSpace;
+        this.s4JActivity = s4JSpace.getS4JActivity();
+    }
+
+    @Override
+    public void onCompletion(Message message) {
+        try {
+            if (logger.isTraceEnabled()) {
+                // for testing purpose
+                String myMsgSeq = message.getStringProperty(S4JActivityUtil.NB_MSG_SEQ_PROP);
+                logger.trace("onCompletion::Async message send successful - message ID {} ({}) "
+                    , message.getJMSMessageID(), myMsgSeq);
+            }
+
+            if (s4JActivity.isTrackingMsgRecvCnt() ) {
+                long totalResponseCnt = s4JSpace.incTotalOpResponseCnt();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("... async op response received so far: {}", totalResponseCnt);
+                }
+            }
+        }
+        catch (JMSException jmsException) {
+            logger.warn("onCompletion::Error retrieving message property - {}", jmsException.getMessage());
+        }
+    }
+
+    @Override
+    public void onException(Message message, Exception e) {
+        try {
+            if (logger.isDebugEnabled()) {
+                // for testing purpose
+                String myMsgSeq = message.getStringProperty(S4JActivityUtil.NB_MSG_SEQ_PROP);
+
+                logger.debug("onException::Async message send failed - message ID {} ({}) "
+                    , message.getJMSMessageID(), myMsgSeq);
+            }
+        }
+        catch (JMSException jmsException) {
+            logger.warn("onException::Unexpected error: " + jmsException.getMessage());
+        }
+    }
+}

--- a/driver-s4j/src/main/java/io/nosqlbench/driver/jms/util/S4JMessageListener.java
+++ b/driver-s4j/src/main/java/io/nosqlbench/driver/jms/util/S4JMessageListener.java
@@ -29,6 +29,9 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 
+/**
+ *  Used for async message consumption
+ */
 public class S4JMessageListener implements MessageListener {
 
     private final static Logger logger = LogManager.getLogger(S4JSpace.class);
@@ -39,6 +42,9 @@ public class S4JMessageListener implements MessageListener {
     private final S4JActivity s4JActivity;
 
     public S4JMessageListener(JMSContext jmsContext, S4JSpace s4JSpace, float msgAckRatio) {
+        assert (jmsContext != null);
+        assert (s4JSpace != null);
+
         this.jmsContext = jmsContext;
         this.s4JSpace = s4JSpace;
         this.s4JActivity = s4JSpace.getS4JActivity();
@@ -64,10 +70,14 @@ public class S4JMessageListener implements MessageListener {
                         , message.getJMSMessageID(), myMsgSeq);
                 }
 
-                s4JSpace.incTotalOpResponseCnt();
+                if (s4JActivity.isTrackingMsgRecvCnt()) {
+                    s4JSpace.incTotalOpResponseCnt();
+                }
             }
             else {
-                s4JSpace.incTotalNullMsgRecvdCnt();
+                if (s4JActivity.isTrackingMsgRecvCnt()) {
+                    s4JSpace.incTotalNullMsgRecvdCnt();
+                }
             }
         }
         catch (JMSException jmsException) {

--- a/driver-s4j/src/main/resources/s4j.md
+++ b/driver-s4j/src/main/resources/s4j.md
@@ -30,6 +30,10 @@ In the above NB CLI command, the S4J driver specific parameters are listed as be
 * session_mode: the session mode used when creating a JMS session
 * web_url: the URL of the Pulsar web service
 * service_url: the URL of the Pulsar native protocol service
+* (optional) max_s4jop_time: maximum time (in seconds) to execute the actual S4J operations (e.g. message sending or receiving). If NB execution time is beyond this limit, each NB cycle is just a no-op. Please NOTE:
+  * this is useful when controlled NB execution is needed with NB CLI scripting.
+  * if this parameter is not specified or the value is 0, it means no time limitation. Every single NB cycle will trigger an actual S4J operation.
+* (optional) track_msg_cnt: When set to true (with default as false), the S4J driver will keep track of the confirmed response count for message sending and receiving.
 
 Other NB engine parameters are straight forward:
 * driver: must be **s4j**


### PR DESCRIPTION
- when the NB execution time exceeds "max_s4jop_time" threshold, the NB S4J becomes no-op (no message production or consumption any more)
- when "track_msg_cnt" is false, don't keep track of S4J operation response count

Remove consumer close() during activity shutdown. Close the underlying connection() directly. Otherwise, it may cause the shutdown activity to be blocked (e.g. close a consumer that is waiting to receive in blocking mode)