### PR TITLE
Set base to 17-jdk so this image can run on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-alpine
+FROM eclipse-temurin:17-jdk
 RUN apk --no-cache add curl
 
 COPY nb5/target/nb5.jar nb5.jar


### PR DESCRIPTION
This allows nosqlbench docker image to run natively on Apple M1 and other ARM Linux environment