### PR TITLE
New consumer subscription feature; fix consumer DLT loading issue; code cleanup and reorg

### DIFF
--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarSpace.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarSpace.java
@@ -119,9 +119,9 @@ public class PulsarSpace implements  AutoCloseable {
 
             // Pulsar Authentication
             String authPluginClassName =
-                pulsarClientConf.getClientConfValue(PulsarAdapterUtil.CLNT_CONF_KEY.authPulginClassName.label);
+                pulsarClientConf.getClientConfValueRaw(PulsarAdapterUtil.CLNT_CONF_KEY.authPulginClassName.label);
             String authParams =
-                pulsarClientConf.getClientConfValue(PulsarAdapterUtil.CLNT_CONF_KEY.authParams.label);
+                pulsarClientConf.getClientConfValueRaw(PulsarAdapterUtil.CLNT_CONF_KEY.authParams.label);
 
             if ( !StringUtils.isAnyBlank(authPluginClassName, authParams) ) {
                 adminBuilder.authentication(authPluginClassName, authParams);
@@ -131,7 +131,7 @@ public class PulsarSpace implements  AutoCloseable {
             boolean useTls = StringUtils.contains(pulsarSvcUrl, "pulsar+ssl");
             if ( useTls ) {
                 String tlsHostnameVerificationEnableStr =
-                    pulsarClientConf.getClientConfValue(PulsarAdapterUtil.CLNT_CONF_KEY.tlsHostnameVerificationEnable.label);
+                    pulsarClientConf.getClientConfValueRaw(PulsarAdapterUtil.CLNT_CONF_KEY.tlsHostnameVerificationEnable.label);
                 boolean tlsHostnameVerificationEnable = BooleanUtils.toBoolean(tlsHostnameVerificationEnableStr);
 
                 adminBuilder
@@ -140,14 +140,14 @@ public class PulsarSpace implements  AutoCloseable {
                     .enableTlsHostnameVerification(tlsHostnameVerificationEnable);
 
                 String tlsTrustCertsFilePath =
-                    pulsarClientConf.getClientConfValue(PulsarAdapterUtil.CLNT_CONF_KEY.tlsTrustCertsFilePath.label);
+                    pulsarClientConf.getClientConfValueRaw(PulsarAdapterUtil.CLNT_CONF_KEY.tlsTrustCertsFilePath.label);
                 if (!StringUtils.isBlank(tlsTrustCertsFilePath)) {
                     adminBuilder.tlsTrustCertsFilePath(tlsTrustCertsFilePath);
                     clientBuilder.tlsTrustCertsFilePath(tlsTrustCertsFilePath);
                 }
 
                 String tlsAllowInsecureConnectionStr =
-                    pulsarClientConf.getClientConfValue(PulsarAdapterUtil.CLNT_CONF_KEY.tlsAllowInsecureConnection.label);
+                    pulsarClientConf.getClientConfValueRaw(PulsarAdapterUtil.CLNT_CONF_KEY.tlsAllowInsecureConnection.label);
                 boolean tlsAllowInsecureConnection = BooleanUtils.toBoolean(tlsAllowInsecureConnectionStr);
                 adminBuilder.allowTlsInsecureConnection(tlsAllowInsecureConnection);
                 clientBuilder.allowTlsInsecureConnection(tlsAllowInsecureConnection);
@@ -188,8 +188,8 @@ public class PulsarSpace implements  AutoCloseable {
 
     private Schema<?> buildSchemaFromDefinition(String schemaTypeConfEntry,
                                                 String schemaDefinitionConfEntry) {
-        String schemaType = pulsarClientConf.getSchemaConfValue(schemaTypeConfEntry);
-        String schemaDef = pulsarClientConf.getSchemaConfValue(schemaDefinitionConfEntry);
+        String schemaType = pulsarClientConf.getSchemaConfValueRaw(schemaTypeConfEntry);
+        String schemaDef = pulsarClientConf.getSchemaConfValueRaw(schemaDefinitionConfEntry);
 
         Schema<?> result;
         if (PulsarAdapterUtil.isAvroSchemaTypeStr(schemaType)) {
@@ -210,11 +210,13 @@ public class PulsarSpace implements  AutoCloseable {
         // this is to allow KEY_VALUE schema
         if (pulsarClientConf.hasSchemaConfKey("schema.key.type")) {
             Schema<?> pulsarKeySchema = buildSchemaFromDefinition("schema.key.type", "schema.key.definition");
-            String encodingType = pulsarClientConf.getSchemaConfValue("schema.keyvalue.encodingtype");
             KeyValueEncodingType keyValueEncodingType = KeyValueEncodingType.SEPARATED;
-            if (encodingType != null) {
+
+            String encodingType = pulsarClientConf.getSchemaConfValueRaw("schema.keyvalue.encodingtype");
+            if (StringUtils.isNotBlank(encodingType)) {
                 keyValueEncodingType = KeyValueEncodingType.valueOf(encodingType);
             }
+
             pulsarSchema = Schema.KeyValue(pulsarKeySchema, pulsarSchema, keyValueEncodingType);
         }
     }

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageConsumerOpDispenser.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageConsumerOpDispenser.java
@@ -35,12 +35,6 @@ public class MessageConsumerOpDispenser extends PulsarClientOpDispenser {
 
     private final static Logger logger = LogManager.getLogger("MessageConsumerOpDispenser");
 
-    public static final String TOPIC_PATTERN_OP_PARAM = "topic_pattern";
-    public static final String SUBSCRIPTION_NAME_OP_PARAM = "subscription_name";
-    public static final String SUBSCRIPTION_TYPE_OP_PARAM = "subscription_type";
-    public static final String CONSUMER_NAME_OP_PARAM = "consumer_name";
-    public static final String RANGES_OP_PARAM = "ranges";
-
     private final LongFunction<String> topicPatternFunc;
     private final LongFunction<String> subscriptionNameFunc;
     private final LongFunction<String> subscriptionTypeFunc;
@@ -49,8 +43,8 @@ public class MessageConsumerOpDispenser extends PulsarClientOpDispenser {
     private final LongFunction<String> e2eStartTimeSrcParamStrFunc;
     private final LongFunction<Consumer> consumerFunction;
 
-    private final ThreadLocal<Map<String, ReceivedMessageSequenceTracker>> receivedMessageSequenceTrackersForTopicThreadLocal =
-        ThreadLocal.withInitial(HashMap::new);
+    private final ThreadLocal<Map<String, ReceivedMessageSequenceTracker>>
+        receivedMessageSequenceTrackersForTopicThreadLocal = ThreadLocal.withInitial(HashMap::new);
 
     public MessageConsumerOpDispenser(DriverAdapter adapter,
                                       ParsedOp op,
@@ -58,11 +52,16 @@ public class MessageConsumerOpDispenser extends PulsarClientOpDispenser {
                                       PulsarSpace pulsarSpace) {
         super(adapter, op, tgtNameFunc, pulsarSpace);
 
-        this.topicPatternFunc = lookupOptionalStrOpValueFunc(TOPIC_PATTERN_OP_PARAM);
-        this.subscriptionNameFunc = lookupMandtoryStrOpValueFunc(SUBSCRIPTION_NAME_OP_PARAM);
-        this.subscriptionTypeFunc = lookupOptionalStrOpValueFunc(SUBSCRIPTION_TYPE_OP_PARAM);
-        this.cycleConsumerNameFunc = lookupOptionalStrOpValueFunc(CONSUMER_NAME_OP_PARAM);
-        this.rangesFunc = lookupOptionalStrOpValueFunc(RANGES_OP_PARAM);
+        this.topicPatternFunc =
+            lookupOptionalStrOpValueFunc(PulsarAdapterUtil.CONSUMER_CONF_STD_KEY.topicsPattern.label);
+        this.subscriptionNameFunc =
+            lookupMandtoryStrOpValueFunc(PulsarAdapterUtil.CONSUMER_CONF_STD_KEY.subscriptionName.label);
+        this.subscriptionTypeFunc =
+            lookupOptionalStrOpValueFunc(PulsarAdapterUtil.CONSUMER_CONF_STD_KEY.subscriptionType.label);
+        this.cycleConsumerNameFunc =
+            lookupOptionalStrOpValueFunc(PulsarAdapterUtil.CONSUMER_CONF_STD_KEY.consumerName.label);
+        this.rangesFunc =
+            lookupOptionalStrOpValueFunc(PulsarAdapterUtil.CONSUMER_CONF_CUSTOM_KEY.ranges.label);
         this.e2eStartTimeSrcParamStrFunc = lookupOptionalStrOpValueFunc(
             PulsarAdapterUtil.DOC_LEVEL_PARAMS.E2E_STARTING_TIME_SOURCE.label, "none");
         this.consumerFunction = (l) -> getConsumer(

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageProducerOpDispenser.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageProducerOpDispenser.java
@@ -18,20 +18,19 @@ package io.nosqlbench.adapter.pulsar.dispensers;
 
 import io.nosqlbench.adapter.pulsar.PulsarSpace;
 import io.nosqlbench.adapter.pulsar.ops.MessageProducerOp;
+import io.nosqlbench.adapter.pulsar.util.PulsarAdapterUtil;
 import io.nosqlbench.engine.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.engine.api.templating.ParsedOp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pulsar.client.api.Producer;
 
-import java.util.Optional;
 import java.util.function.LongFunction;
 
 public class MessageProducerOpDispenser extends PulsarClientOpDispenser {
 
     private final static Logger logger = LogManager.getLogger("MessageProducerOpDispenser");
 
-    public static final String PRODUCER_NAME_OP_PARAM = "producer_name";
     public static final String MSG_KEY_OP_PARAM = "msg_key";
     public static final String MSG_PROP_OP_PARAM = "msg_prop";
     public static final String MSG_VALUE_OP_PARAM = "msg_value";
@@ -48,7 +47,8 @@ public class MessageProducerOpDispenser extends PulsarClientOpDispenser {
                                       PulsarSpace pulsarSpace) {
         super(adapter, op, tgtNameFunc, pulsarSpace);
 
-        this.cycleProducerNameFunc = lookupOptionalStrOpValueFunc(PRODUCER_NAME_OP_PARAM);
+        this.cycleProducerNameFunc =
+            lookupOptionalStrOpValueFunc(PulsarAdapterUtil.PRODUCER_CONF_STD_KEY.producerName.label);
         this.producerFunc = (l) -> getProducer(tgtNameFunc.apply(l), cycleProducerNameFunc.apply(l));
         this.msgKeyFunc = lookupOptionalStrOpValueFunc(MSG_KEY_OP_PARAM);
         this.msgPropFunc = lookupOptionalStrOpValueFunc(MSG_PROP_OP_PARAM);
@@ -65,7 +65,7 @@ public class MessageProducerOpDispenser extends PulsarClientOpDispenser {
             useTransactFunc.apply(cycle),
             seqTrackingFunc.apply(cycle),
             transactSupplierFunc.apply(cycle),
-            errSimuTypeSetFunc.apply(cycle),
+            msgSeqErrSimuTypeSetFunc.apply(cycle),
             producerFunc.apply(cycle),
             msgKeyFunc.apply(cycle),
             msgPropFunc.apply(cycle),

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageReaderOpDispenser.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/MessageReaderOpDispenser.java
@@ -43,7 +43,8 @@ public class MessageReaderOpDispenser extends PulsarClientOpDispenser {
                                     PulsarSpace pulsarSpace) {
         super(adapter, op, tgtNameFunc, pulsarSpace);
 
-        this.cycleReaderNameFunc = lookupMandtoryStrOpValueFunc("reader_name");
+        this.cycleReaderNameFunc =
+            lookupMandtoryStrOpValueFunc(PulsarAdapterUtil.READER_CONF_STD_KEY.readerName.label);
         this.msgStartPosStrFunc = lookupOptionalStrOpValueFunc(
             "start_msg_position", PulsarAdapterUtil.READER_MSG_POSITION_TYPE.earliest.label);
         this.readerFunc = (l) -> getReader(

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/PulsarClientOpDispenser.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/PulsarClientOpDispenser.java
@@ -49,7 +49,7 @@ public abstract class PulsarClientOpDispenser extends PulsarBaseOpDispenser {
     protected final LongFunction<Boolean> seqTrackingFunc;
     protected final LongFunction<String> payloadRttFieldFunc;
     protected final LongFunction<Supplier<Transaction>> transactSupplierFunc;
-    protected final LongFunction<Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE>> errSimuTypeSetFunc;
+    protected final LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> msgSeqErrSimuTypeSetFunc;
 
     public PulsarClientOpDispenser(DriverAdapter adapter,
                                    ParsedOp op,
@@ -79,7 +79,7 @@ public abstract class PulsarClientOpDispenser extends PulsarBaseOpDispenser {
 
         this.transactSupplierFunc = (l) -> getTransactionSupplier();
 
-        this.errSimuTypeSetFunc = getStaticErrSimuTypeSetOpValueFunc();
+        this.msgSeqErrSimuTypeSetFunc = getStaticErrSimuTypeSetOpValueFunc();
     }
 
     protected Supplier<Transaction> getTransactionSupplier() {
@@ -101,16 +101,16 @@ public abstract class PulsarClientOpDispenser extends PulsarBaseOpDispenser {
         };
     }
 
-    protected LongFunction<Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE>> getStaticErrSimuTypeSetOpValueFunc() {
-        LongFunction<Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE>> setStringLongFunction;
+    protected LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> getStaticErrSimuTypeSetOpValueFunc() {
+        LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> setStringLongFunction;
         setStringLongFunction = (l) -> parsedOp.getOptionalStaticValue("seqerr_simu", String.class)
             .filter(Predicate.not(String::isEmpty))
             .map(value -> {
-                Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> set = new HashSet<>();
+                Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> set = new HashSet<>();
 
                 if (StringUtils.contains(value,',')) {
                     set = Arrays.stream(value.split(","))
-                        .map(PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE::parseSimuType)
+                        .map(PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE::parseSimuType)
                         .filter(Optional::isPresent)
                         .map(Optional::get)
                         .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/ops/MessageProducerOp.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/ops/MessageProducerOp.java
@@ -49,7 +49,7 @@ public class MessageProducerOp extends PulsarClientOp {
     private final boolean useTransact;
     private final boolean seqTracking;
     private final Supplier<Transaction> transactSupplier;
-    private final Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> errSimuTypeSet;
+    private final Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> errSimuTypeSet;
     private final Producer<?> producer;
     private final String msgKey;
     private final String msgPropRawJsonStr;
@@ -66,7 +66,7 @@ public class MessageProducerOp extends PulsarClientOp {
                              boolean useTransact,
                              boolean seqTracking,
                              Supplier<Transaction> transactSupplier,
-                             Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> errSimuTypeSet,
+                             Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> errSimuTypeSet,
                              Producer<?> producer,
                              String msgKey,
                              String msgProp,
@@ -142,15 +142,6 @@ public class MessageProducerOp extends PulsarClientOp {
         int messageSize;
         SchemaType schemaType = pulsarSchema.getSchemaInfo().getType();
         if (pulsarSchema instanceof KeyValueSchema) {
-
-//            // {KEY IN JSON}||{VALUE IN JSON}
-//            int separator = msgValue.indexOf("}||{");
-//            if (separator < 0) {
-//                throw new IllegalArgumentException("KeyValue payload MUST be in form {KEY IN JSON}||{VALUE IN JSON} (with 2 pipes that separate the KEY part from the VALUE part)");
-//            }
-//            String keyInput = msgValue.substring(0, separator + 1);
-//            String valueInput = msgValue.substring(separator + 3);
-
             KeyValueSchema keyValueSchema = (KeyValueSchema) pulsarSchema;
             org.apache.avro.Schema avroSchema = getAvroSchemaFromConfiguration();
             GenericRecord payload = PulsarAvroSchemaUtil.GetGenericRecord_PulsarAvro(

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/MessageSequenceNumberSendingHandler.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/MessageSequenceNumberSendingHandler.java
@@ -18,7 +18,6 @@ package io.nosqlbench.adapter.pulsar.util;
  */
 
 
-import io.nosqlbench.adapter.pulsar.util.PulsarAdapterUtil;
 import org.apache.commons.lang3.RandomUtils;
 
 import java.util.ArrayDeque;
@@ -34,16 +33,16 @@ public class MessageSequenceNumberSendingHandler {
     long number = 1;
     Queue<Long> outOfOrderNumbers;
 
-    public long getNextSequenceNumber(Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes) {
+    public long getNextSequenceNumber(Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes) {
         return getNextSequenceNumber(simulatedErrorTypes, SIMULATED_ERROR_PROBABILITY_PERCENTAGE);
     }
 
-    long getNextSequenceNumber(Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes, int errorProbabilityPercentage) {
+    long getNextSequenceNumber(Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes, int errorProbabilityPercentage) {
         simulateError(simulatedErrorTypes, errorProbabilityPercentage);
         return nextNumber();
     }
 
-    private void simulateError(Set<PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes, int errorProbabilityPercentage) {
+    private void simulateError(Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> simulatedErrorTypes, int errorProbabilityPercentage) {
         if (!simulatedErrorTypes.isEmpty() && shouldSimulateError(errorProbabilityPercentage)) {
             int selectIndex = 0;
             int numberOfErrorTypes = simulatedErrorTypes.size();
@@ -51,7 +50,7 @@ public class MessageSequenceNumberSendingHandler {
                 // pick one of the simulated error type randomly
                 selectIndex = RandomUtils.nextInt(0, numberOfErrorTypes);
             }
-            PulsarAdapterUtil.SEQ_ERROR_SIMU_TYPE errorType = simulatedErrorTypes.stream()
+            PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE errorType = simulatedErrorTypes.stream()
                 .skip(selectIndex)
                 .findFirst()
                 .get();

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterUtil.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterUtil.java
@@ -83,6 +83,29 @@ public class PulsarAdapterUtil {
         return Arrays.stream(PULSAR_API_TYPE.values()).map(t -> t.label).collect(Collectors.joining(", "));
     }
 
+
+    ///////
+    // Valid configuration categories
+    public enum CONF_GATEGORY {
+        Schema("schema"),
+        Client("client"),
+        Producer("producer"),
+        Consumer("consumer"),
+        Reader("reader");
+
+        public final String label;
+
+        CONF_GATEGORY(String label) {
+            this.label = label;
+        }
+    }
+    public static boolean isValidConfCategory(String item) {
+        return Arrays.stream(CONF_GATEGORY.values()).anyMatch(t -> t.label.equals(item));
+    }
+    public static String getValidConfCategoryList() {
+        return Arrays.stream(CONF_GATEGORY.values()).map(t -> t.label).collect(Collectors.joining(", "));
+    }
+
     ///////
     // Valid persistence type
     public enum PERSISTENT_TYPES {
@@ -165,6 +188,27 @@ public class PulsarAdapterUtil {
         return Arrays.stream(PRODUCER_CONF_STD_KEY.values()).anyMatch(t -> t.label.equals(item));
     }
 
+    // compressionType
+    public enum COMPRESSION_TYPE {
+        NONE("NONE"),
+        LZ4("LZ4"),
+        ZLIB("ZLIB"),
+        ZSTD("ZSTD"),
+        SNAPPY("SNAPPY");
+
+        public final String label;
+
+        COMPRESSION_TYPE(String label) {
+            this.label = label;
+        }
+    }
+    public static boolean isValidCompressionType(String item) {
+        return Arrays.stream(COMPRESSION_TYPE.values()).anyMatch(t -> t.label.equals(item));
+    }
+    public static String getValidCompressionTypeList() {
+        return Arrays.stream(COMPRESSION_TYPE.values()).map(t -> t.label).collect(Collectors.joining(", "));
+    }
+
     ///////
     // Standard consumer configuration (activity-level settings)
     // - https://pulsar.apache.org/docs/en/client-libraries-java/#consumer
@@ -189,7 +233,12 @@ public class PulsarAdapterUtil {
         regexSubscriptionMode("regexSubscriptionMode"),
         deadLetterPolicy("deadLetterPolicy"),
         autoUpdatePartitions("autoUpdatePartitions"),
-        replicateSubscriptionState("replicateSubscriptionState");
+        replicateSubscriptionState("replicateSubscriptionState"),
+        negativeAckRedeliveryBackoff("negativeAckRedeliveryBackoff"),
+        ackTimeoutRedeliveryBackoff("ackTimeoutRedeliveryBackoff"),
+        autoAckOldestChunkedMessageOnQueueFull("autoAckOldestChunkedMessageOnQueueFull"),
+        maxPendingChunkedMessage("maxPendingChunkedMessage"),
+        expireTimeOfIncompleteChunkedMessageMillis("expireTimeOfIncompleteChunkedMessageMillis");
 
         public final String label;
 
@@ -206,7 +255,8 @@ public class PulsarAdapterUtil {
     // - NOT part of https://pulsar.apache.org/docs/en/client-libraries-java/#consumer
     // - NB Pulsar driver consumer operation specific
     public enum CONSUMER_CONF_CUSTOM_KEY {
-        timeout("timeout");
+        timeout("timeout"),
+        ranges("ranges");
 
         public final String label;
 
@@ -218,8 +268,7 @@ public class PulsarAdapterUtil {
         return Arrays.stream(CONSUMER_CONF_CUSTOM_KEY.values()).anyMatch(t -> t.label.equals(item));
     }
 
-    ///////
-    // Pulsar subscription type
+    // subscriptionTyp
     public enum SUBSCRIPTION_TYPE {
         Exclusive("Exclusive"),
         Failover("Failover"),
@@ -237,6 +286,43 @@ public class PulsarAdapterUtil {
     }
     public static String getValidSubscriptionTypeList() {
         return Arrays.stream(SUBSCRIPTION_TYPE.values()).map(t -> t.label).collect(Collectors.joining(", "));
+    }
+
+    // subscriptionInitialPosition
+    public enum SUBSCRIPTION_INITIAL_POSITION {
+        Earliest("Earliest"),
+        Latest("Latest");
+
+        public final String label;
+
+        SUBSCRIPTION_INITIAL_POSITION(String label) {
+            this.label = label;
+        }
+    }
+    public static boolean isValidSubscriptionInitialPosition(String item) {
+        return Arrays.stream(SUBSCRIPTION_INITIAL_POSITION.values()).anyMatch(t -> t.label.equals(item));
+    }
+    public static String getValidSubscriptionInitialPositionList() {
+        return Arrays.stream(SUBSCRIPTION_INITIAL_POSITION.values()).map(t -> t.label).collect(Collectors.joining(", "));
+    }
+
+    // regexSubscriptionMode
+    public enum REGEX_SUBSCRIPTION_MODE {
+        Persistent("PersistentOnly"),
+        NonPersistent("NonPersistentOnly"),
+        All("AllTopics");
+
+        public final String label;
+
+        REGEX_SUBSCRIPTION_MODE(String label) {
+            this.label = label;
+        }
+    }
+    public static boolean isValidRegexSubscriptionMode(String item) {
+        return Arrays.stream(REGEX_SUBSCRIPTION_MODE.values()).anyMatch(t -> t.label.equals(item));
+    }
+    public static String getValidRegexSubscriptionModeList() {
+        return Arrays.stream(REGEX_SUBSCRIPTION_MODE.values()).map(t -> t.label).collect(Collectors.joining(", "));
     }
 
     ///////
@@ -284,8 +370,7 @@ public class PulsarAdapterUtil {
     // Valid read positions for a Pulsar reader
     public enum READER_MSG_POSITION_TYPE {
         earliest("earliest"),
-        latest("latest"),
-        custom("custom");
+        latest("latest");
 
         public final String label;
 
@@ -298,22 +383,22 @@ public class PulsarAdapterUtil {
     }
 
     ///////
-    // Pulsar subscription type
-    public enum SEQ_ERROR_SIMU_TYPE {
+    // Message processing sequence error simulation types
+    public enum MSG_SEQ_ERROR_SIMU_TYPE {
         OutOfOrder("out_of_order"),
         MsgLoss("msg_loss"),
         MsgDup("msg_dup");
 
         public final String label;
 
-        SEQ_ERROR_SIMU_TYPE(String label) {
+        MSG_SEQ_ERROR_SIMU_TYPE(String label) {
             this.label = label;
         }
 
-        private static final Map<String, SEQ_ERROR_SIMU_TYPE> MAPPING = new HashMap<>();
+        private static final Map<String, MSG_SEQ_ERROR_SIMU_TYPE> MAPPING = new HashMap<>();
 
         static {
-            for (SEQ_ERROR_SIMU_TYPE simuType : values()) {
+            for (MSG_SEQ_ERROR_SIMU_TYPE simuType : values()) {
                 MAPPING.put(simuType.label, simuType);
                 MAPPING.put(simuType.label.toLowerCase(), simuType);
                 MAPPING.put(simuType.label.toUpperCase(), simuType);
@@ -323,40 +408,15 @@ public class PulsarAdapterUtil {
             }
         }
 
-        public static Optional<SEQ_ERROR_SIMU_TYPE> parseSimuType(String simuTypeString) {
+        public static Optional<MSG_SEQ_ERROR_SIMU_TYPE> parseSimuType(String simuTypeString) {
             return Optional.ofNullable(MAPPING.get(simuTypeString.trim()));
         }
     }
     public static boolean isValidSeqErrSimuType(String item) {
-        return Arrays.stream(SEQ_ERROR_SIMU_TYPE.values()).anyMatch(t -> t.label.equals(item));
+        return Arrays.stream(MSG_SEQ_ERROR_SIMU_TYPE.values()).anyMatch(t -> t.label.equals(item));
     }
     public static String getValidSeqErrSimuTypeList() {
-        return Arrays.stream(SEQ_ERROR_SIMU_TYPE.values()).map(t -> t.label).collect(Collectors.joining(", "));
-    }
-
-    ///////
-    // Valid websocket-producer configuration (activity-level settings)
-    // TODO: to be added
-    public enum WEBSKT_PRODUCER_CONF_KEY {
-        ;
-
-        public final String label;
-
-        WEBSKT_PRODUCER_CONF_KEY(String label) {
-            this.label = label;
-        }
-    }
-
-    ///////
-    // Valid managed-ledger configuration (activity-level settings)
-    // TODO: to be added
-    public enum MANAGED_LEDGER_CONF_KEY {
-        ;
-
-        public final String label;
-        MANAGED_LEDGER_CONF_KEY(String label) {
-            this.label = label;
-        }
+        return Arrays.stream(MSG_SEQ_ERROR_SIMU_TYPE.values()).map(t -> t.label).collect(Collectors.joining(", "));
     }
 
     ///////
@@ -384,6 +444,10 @@ public class PulsarAdapterUtil {
     }
     public static Schema<?> getPrimitiveTypeSchema(String typeStr) {
         Schema<?> schema;
+
+        if (StringUtils.isBlank(typeStr)) {
+            typeStr = "BYTES";
+        }
 
         switch (typeStr.toUpperCase()) {
             case "BOOLEAN":
@@ -428,14 +492,12 @@ public class PulsarAdapterUtil {
             case "LOCAL_DATE_TIME":
                 schema = Schema.LOCAL_DATE_TIME;
                 break;
-            // Use BYTES as the default schema type if the type string is not specified
-            case "":
             case "BYTES":
                 schema = Schema.BYTES;
                 break;
             // Report an error if non-valid, non-empty schema type string is provided
             default:
-                throw new RuntimeException("Invalid Pulsar primitive schema type string : " + typeStr);
+                throw new PulsarAdapterInvalidParamException("Invalid Pulsar primitive schema type string : " + typeStr);
         }
 
         return schema;
@@ -444,15 +506,12 @@ public class PulsarAdapterUtil {
     ///////
     // Complex strut type: Avro or Json
     public static boolean isAvroSchemaTypeStr(String typeStr) {
-        return typeStr.equalsIgnoreCase("AVRO");
-    }
-    public static boolean isKeyValueTypeStr(String typeStr) {
-        return typeStr.equalsIgnoreCase("KEY_VALUE");
+        return (StringUtils.isNotBlank(typeStr) && typeStr.equalsIgnoreCase("AVRO"));
     }
 
     // automatic decode the type from the Registry
     public static boolean isAutoConsumeSchemaTypeStr(String typeStr) {
-        return typeStr.equalsIgnoreCase("AUTO_CONSUME");
+        return (StringUtils.isNotBlank(typeStr) && typeStr.equalsIgnoreCase("AUTO_CONSUME"));
     }
     public static Schema<?> getAvroSchema(String typeStr, String definitionStr) {
         String schemaDefinitionStr = definitionStr;

--- a/adapter-pulsar/src/main/resources/config.properties
+++ b/adapter-pulsar/src/main/resources/config.properties
@@ -22,7 +22,6 @@ client.connectionTimeoutMs=5000
 client.authPluginClassName=org.apache.pulsar.client.impl.auth.AuthenticationToken
 # Cluster admin
 client.authParams=
-client.tlsAllowInsecureConnection=true
 
 
 ### Producer related configurations (global) - producer.xxx
@@ -35,18 +34,12 @@ producer.blockIfQueueFull=true
 
 ### Consumer related configurations (global) - consumer.xxx
 # http://pulsar.apache.org/docs/en/client-libraries-java/#configure-consumer
-consumer.topicNames=
-consumer.topicsPattern=
-consumer.subscriptionName=
-consumer.subscriptionType=
-consumer.consumerName=
-consumer.receiverQueueSize=
+consumer.subscriptionInitialPosition=Earliest
+consumer.ackTimeoutMillis=10000
+consumer.regexSubscriptionMode=AllTopics
+consumer.deadLetterPolicy={"maxRedeliverCount":"5","retryLetterTopic":"public/default/retry","deadLetterTopic":"public/default/dlq","initialSubscriptionName":"dlq-sub"}
+consumer.ackTimeoutRedeliveryBackoff={"minDelayMs":"10","maxDelayMs":"20","multiplier":"1.2"}
 
 
 ### Reader related configurations (global) - reader.xxx
 # https://pulsar.apache.org/docs/en/client-libraries-java/#reader
-# - valid Pos: earliest, latest, custom::file://<path>/<to>/<message_id_file>
-reader.topicName=
-reader.receiverQueueSize=
-reader.readerName=
-reader.startMessagePos=earliest

--- a/adapter-pulsar/src/main/resources/msg_proc_kvraw.yaml
+++ b/adapter-pulsar/src/main/resources/msg_proc_kvraw.yaml
@@ -30,5 +30,5 @@ blocks:
     ops:
       op1:
         MessageConsume: "tnt0/ns0/tp0"
-        subscription_name: "mynbsub"
-#        subscription_type: "shared"
+        subscriptionName: "mynbsub"
+        subscriptionType: "Shared"

--- a/adapters-api/src/main/java/io/nosqlbench/engine/api/activityimpl/BaseOpDispenser.java
+++ b/adapters-api/src/main/java/io/nosqlbench/engine/api/activityimpl/BaseOpDispenser.java
@@ -39,7 +39,7 @@ public abstract class BaseOpDispenser<T extends Op, S> implements OpDispenser<T>
 
     private final String name;
     protected final DriverAdapter<T, S> adapter;
-    protected boolean instrument;
+    private boolean instrument;
     private Histogram resultSizeHistogram;
     private Timer successTimer;
     private Timer errorTimer;

--- a/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/ActivityMetrics.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/ActivityMetrics.java
@@ -83,15 +83,6 @@ public class ActivityMetrics {
         return metric;
     }
 
-    private static Metric register(String fullMetricName, MetricProvider metricProvider) {
-        Metric metric = get().getMetrics().get(fullMetricName);
-        if (metric == null) {
-            metric = metricProvider.getMetric();
-            return get().register(fullMetricName, metric);
-        }
-        return metric;
-    }
-
     private static Metric register(ScriptContext context, String name, MetricProvider metricProvider) {
         Metric metric = get().getMetrics().get(name);
         if (metric == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
                 <module>driver-jmx</module>
                 <module>driver-jdbc</module>
                 <module>driver-cockroachdb</module>
-                <!--<module>driver-pulsar</module>-->
 
             </modules>
         </profile>


### PR DESCRIPTION
Added support for 1) subscription initial position and 2) regex subscription mode

Also fixed a consumer configuration loading issue with Dlt/negAck/ackTimeout policy using Pulsar client's loadConf() API.

Addressed the review comments in PR #791; reverted the changes in ActivityMetrics and BasedOpDispenser