### PR TITLE
Regular Expression Inefficiency fixes

### DIFF
--- a/nb-api/src/main/java/io/nosqlbench/api/engine/util/SSLKsFactory.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/util/SSLKsFactory.java
@@ -46,7 +46,8 @@ public class SSLKsFactory implements NBMapConfigurable {
     private static final SSLKsFactory instance = new SSLKsFactory();
 
     private static final Pattern CERT_PATTERN = Pattern.compile("-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n){1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*CERTIFICATE[^-]*-+", Pattern.CASE_INSENSITIVE);
-    private static final Pattern KEY_PATTERN = Pattern.compile("-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n){1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", Pattern.CASE_INSENSITIVE);public static final String SSL = "ssl";
+    private static final Pattern KEY_PATTERN = Pattern.compile("-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n){1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", Pattern.CASE_INSENSITIVE);
+    public static final String SSL = "ssl";
     public static final String DEFAULT_TLSVERSION = "TLSv1.2";
 
     /**

--- a/nb-api/src/main/java/io/nosqlbench/api/engine/util/SSLKsFactory.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/util/SSLKsFactory.java
@@ -45,9 +45,8 @@ public class SSLKsFactory implements NBMapConfigurable {
 
     private static final SSLKsFactory instance = new SSLKsFactory();
 
-    private static final Pattern CERT_PATTERN = Pattern.compile("-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+([a-z0-9+/=\\r\\n]+)-+END\\s+.*CERTIFICATE[^-]*-+", 2);
-    private static final Pattern KEY_PATTERN = Pattern.compile("-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+([a-z0-9+/=\\r\\n]+)-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", 2);
-    public static final String SSL = "ssl";
+    private static final Pattern CERT_PATTERN = Pattern.compile("-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n){1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*CERTIFICATE[^-]*-+", Pattern.CASE_INSENSITIVE);
+    private static final Pattern KEY_PATTERN = Pattern.compile("-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n){1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", Pattern.CASE_INSENSITIVE);public static final String SSL = "ssl";
     public static final String DEFAULT_TLSVERSION = "TLSv1.2";
 
     /**

--- a/virtdata-api/src/main/java/io/nosqlbench/virtdata/api/annotations/ExampleData.java
+++ b/virtdata-api/src/main/java/io/nosqlbench/virtdata/api/annotations/ExampleData.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 public class ExampleData {
 
     public static Pattern CTOR_PATTERN = Pattern.compile("(?<funcname>[^)]+)\\((?<args>.+)\\)");
-    public static Pattern VALS_PATTERN = Pattern.compile("\\[(?<values>-?\\d+([,-. ]+-?\\d+)*)]");
+    public static Pattern VALS_PATTERN = Pattern.compile("\\[(?<values>-?\\d+([,\\-. ]{1,2}-?\\d+)*)]");
     private final Pattern COMMA_VALS = Pattern.compile("\\[(?<vals>-?\\d+(,-?\\d+)*)]");
     private final Pattern RANGE_VALS = Pattern.compile("\\[(?<from>-?\\d+)\\.\\.(?<to>-?\\d+)( +(?<step>-?\\d+))?]");
 

--- a/virtdata-api/src/main/java/io/nosqlbench/virtdata/core/bindings/CompatibilityFixups.java
+++ b/virtdata-api/src/main/java/io/nosqlbench/virtdata/core/bindings/CompatibilityFixups.java
@@ -61,7 +61,7 @@ public class CompatibilityFixups {
     private static final String COMPUTE = "compute_";
     private static final String INTERPOLATE = "interpolate_";
 
-    private final static Pattern oldcurve = Pattern.compile("(?<name>\\b[\\w_]+)(?<lparen>\\()(?<args>.*?)(?<rparen>\\))");
+    private final static Pattern oldcurve = Pattern.compile("(?<name>[\\w_]+)(?<lparen>\\()(?<args>.*?)(?<rparen>\\))");
 
     private final static CompatibilityFixups instance = new CompatibilityFixups();
 

--- a/virtdata-api/src/main/java/io/nosqlbench/virtdata/core/bindings/CompatibilityFixups.java
+++ b/virtdata-api/src/main/java/io/nosqlbench/virtdata/core/bindings/CompatibilityFixups.java
@@ -61,7 +61,7 @@ public class CompatibilityFixups {
     private static final String COMPUTE = "compute_";
     private static final String INTERPOLATE = "interpolate_";
 
-    private final static Pattern oldcurve = Pattern.compile("(?<name>[\\w_]+)(?<lparen>\\()(?<args>.*?)(?<rparen>\\))");
+    private final static Pattern oldcurve = Pattern.compile("\\b(?<name>[\\w_]{1,512})(?<lparen>\\()(?<args>.*?)(?<rparen>\\))");
 
     private final static CompatibilityFixups instance = new CompatibilityFixups();
 


### PR DESCRIPTION
 + Provided limited number of newlines in SSL KEY and CERT Patterns in Regex, Named the flag for more clarity
 + Corrected non-escaped minus sign in regex, and limited delimeter characters to a maximum of 2 to account for comma-space separated values
 + Limited name length to limit user input causing slow regex run, Removed starting boundary delimiter