### PR TITLE
fix for #964

### DIFF
--- a/engine-api/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
+++ b/engine-api/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
@@ -109,7 +109,7 @@ public class SimpleActivity implements Activity, ProgressCapable, ActivityDefObs
     }
 
     @Override
-    public void initActivity() {
+    public synchronized void initActivity() {
         initOrUpdateRateLimiters(this.activityDef);
     }
 
@@ -353,7 +353,7 @@ public class SimpleActivity implements Activity, ProgressCapable, ActivityDefObs
      *
      * @param seq - The {@link OpSequence} to derive the defaults from
      */
-    public void setDefaultsFromOpSequence(OpSequence<?> seq) {
+    public synchronized void setDefaultsFromOpSequence(OpSequence<?> seq) {
         Optional<String> strideOpt = getParams().getOptionalString("stride");
         if (strideOpt.isEmpty()) {
             String stride = String.valueOf(seq.getSequence().length);

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/activity/ActivityExecutor.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/activity/ActivityExecutor.java
@@ -417,7 +417,7 @@ public class ActivityExecutor implements ActivityController, ParameterMap.Listen
         }
     }
 
-    public void startActivity() {
+    public synchronized void startActivity() {
         // we need an executor service to run motor threads on
         startMotorExecutorService();
         startRunningActivityThreads();


### PR DESCRIPTION
It appears that the initializer logic for activity parameters was happening *after* activity threads tried to read the sanitized value for threads=auto. These synchronized methods seem to fix the issue, but we should really do some bisecting to find out the operative change that broke the behavior and improve the design from that point.

closes #964