### PR TITLE
Simplify and optimize Pulsar driver schema type mapping

### DIFF
--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -380,7 +380,7 @@ public class PulsarActivityUtil {
                 if (schemaDefinitionStr.startsWith("file://")) {
                     try {
                         Path filePath = Paths.get(URI.create(schemaDefinitionStr));
-                        schemaDefinitionStr = Files.readString(filePath, StandardCharsets.US_ASCII);
+                        schemaDefinitionStr = Files.readString(filePath, StandardCharsets.UTF_8);
                     } catch (IOException ioe) {
                         throw new RuntimeException("Error reading the specified \"Avro\" schema definition file: " + definitionStr + ": " + ioe.getMessage());
                     }

--- a/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
+++ b/driver-pulsar/src/main/java/io/nosqlbench/driver/pulsar/util/PulsarActivityUtil.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 
 import java.io.IOException;
 import java.net.URI;
@@ -332,85 +334,23 @@ public class PulsarActivityUtil {
         }
     }
 
+    private static final Map<String, Schema<?>> PRIMITIVE_SCHEMA_TYPE_MAPPING = Stream.of(SchemaType.values())
+        .filter(SchemaType::isPrimitive)
+        .collect(Collectors.toUnmodifiableMap(schemaType -> schemaType.name().toUpperCase(),
+            schemaType -> Schema.getSchema(SchemaInfo.builder().type(schemaType).build())));
+
     ///////
     // Primitive Schema type
     public static boolean isPrimitiveSchemaTypeStr(String typeStr) {
-        boolean isPrimitive = false;
-
-        // Use "BYTES" as the default type if the type string is not explicitly specified
-        if (StringUtils.isBlank(typeStr)) {
-            typeStr = "BYTES";
-        }
-
-        if (typeStr.equalsIgnoreCase("BOOLEAN") || typeStr.equalsIgnoreCase("INT8") ||
-            typeStr.equalsIgnoreCase("INT16") || typeStr.equalsIgnoreCase("INT32") ||
-            typeStr.equalsIgnoreCase("INT64") || typeStr.equalsIgnoreCase("FLOAT") ||
-            typeStr.equalsIgnoreCase("DOUBLE") || typeStr.equalsIgnoreCase("BYTES") ||
-            typeStr.equalsIgnoreCase("DATE") || typeStr.equalsIgnoreCase("TIME") ||
-            typeStr.equalsIgnoreCase("TIMESTAMP") || typeStr.equalsIgnoreCase("INSTANT") ||
-            typeStr.equalsIgnoreCase("LOCAL_DATE") || typeStr.equalsIgnoreCase("LOCAL_TIME") ||
-            typeStr.equalsIgnoreCase("LOCAL_DATE_TIME")) {
-            isPrimitive = true;
-        }
-
-        return isPrimitive;
+        return StringUtils.isBlank(typeStr) || PRIMITIVE_SCHEMA_TYPE_MAPPING.containsKey(typeStr.toUpperCase());
     }
+
     public static Schema<?> getPrimitiveTypeSchema(String typeStr) {
-        Schema<?> schema;
-
-        switch (typeStr.toUpperCase()) {
-            case "BOOLEAN":
-                schema = Schema.BOOL;
-                break;
-            case "INT8":
-                schema = Schema.INT8;
-                break;
-            case "INT16":
-                schema = Schema.INT16;
-                break;
-            case "INT32":
-                schema = Schema.INT32;
-                break;
-            case "INT64":
-                schema = Schema.INT64;
-                break;
-            case "FLOAT":
-                schema = Schema.FLOAT;
-                break;
-            case "DOUBLE":
-                schema = Schema.DOUBLE;
-                break;
-            case "DATE":
-                schema = Schema.DATE;
-                break;
-            case "TIME":
-                schema = Schema.TIME;
-                break;
-            case "TIMESTAMP":
-                schema = Schema.TIMESTAMP;
-                break;
-            case "INSTANT":
-                schema = Schema.INSTANT;
-                break;
-            case "LOCAL_DATE":
-                schema = Schema.LOCAL_DATE;
-                break;
-            case "LOCAL_TIME":
-                schema = Schema.LOCAL_TIME;
-                break;
-            case "LOCAL_DATE_TIME":
-                schema = Schema.LOCAL_DATE_TIME;
-                break;
-            // Use BYTES as the default schema type if the type string is not specified
-            case "":
-            case "BYTES":
-                schema = Schema.BYTES;
-                break;
-            // Report an error if non-valid, non-empty schema type string is provided
-            default:
-                throw new RuntimeException("Invalid Pulsar primitive schema type string : " + typeStr);
+        String lookupKey = StringUtils.isBlank(typeStr) ? "BYTES" : typeStr.toUpperCase();
+        Schema<?> schema = PRIMITIVE_SCHEMA_TYPE_MAPPING.get(lookupKey);
+        if (schema == null) {
+            throw new RuntimeException("Invalid Pulsar primitive schema type string : " + typeStr);
         }
-
         return schema;
     }
 


### PR DESCRIPTION
### Motivation

PulsarActivityUtil contains a lot of unnecessary logic for mapping a Pulsar SchemaType name to a Schema instance. 
This could be replaced with the usage of Pulsar client's functionality. Besides being verbose, this could be considered as not very optimal from performance perspective, although this part of the code hasn't been a performance bottleneck.

One part that should be cached is the Avro schema parsing. I don't have profiling results, but it's fairly obvious that a performance tool shouldn't be adding overhead by reading a schema file from disk, possibly in every cycle.

### Modifications

- simplity Pulsar SchemaType name mapping to Schema instance
- add caching to Avro schema parsing
- Use UTF8 encoding for reading Avro schema files. It was US_ASCII, which doesn't make sense.

