### PR TITLE
Configuring all-contributors into the repo

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,100 @@
+{ "projectName": "nosqlbench",
+  "projectOwner": "nosqlbench",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["CONTRIBUTING.md"],
+  "imageSize": 50,
+  "commit": false,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/github/all-contributors/<%= projectOwner %>/<%= projectName %>?color=ee8449&style=flat-square)](#contributors)",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "types": {
+    "custom": {
+      "symbol": "🔭",
+      "description": "A custom contribution type.",
+      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
+    }
+  },
+  "linkToUsage": false,
+  "skipCi": true,
+  "contributors": [
+    {
+      "login": "jshook",
+      "name": "Jonathan Shook",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2148847?v=4",
+      "profile": "https://github.com/jshook",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk",
+        "mentoring",
+        "platform",
+        "projectManagement",
+        "research",
+        
+      ]
+    },
+    {
+      "login": "phact",
+      "name": "Sebastián Estévez",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1313220?v=4",
+      "profile": "https://www.sestevez.com",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "yabinmeng",
+      "name": "Yabin Meng",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16789452?v=4",
+      "profile": "https://github.com/yabinmeng",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "MikeYaacoubStax",
+      "name": "Mike Yaacoub",
+      "avatar_url": "https://avatars.githubusercontent.com/u/117678633?v=4",
+      "profile": "https://github.com/MikeYaacoubStax",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "jeffbanks",
+      "name": "Jeff Banks",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4078933?v=4",
+      "profile": "https://github.com/jeffbanks",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "msmygit",
+      "name": "Madhavan S.",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19366623?v=4",
+      "profile": "https://github.com/msmygit",
+      "contributions": [
+        "question",
+        "doc",
+        "review",
+        "talk"
+      ]
+    },
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+[![All Contributors](https://img.shields.io/github/all-contributors/nosqlbench/nosqlbench?color=ee8449&style=flat-square)](#contributors)
+
 NoSQLBench is an ambitious project. It aims to solve long-standing problems in distributed systems
 testing. There are *many* ways you can contribute! Please take a moment to review this document
 in order to make the contribution process easy and effective for everyone involved.
@@ -117,5 +119,17 @@ are eager to get it into the hands of users who need it.
   [discord server](https://discord.gg/dBHRakusMN) and raise your hand!
 
 
+## Contributors! :sparkle:
+Thanks to these contributors!
+For recognizing contributions, please follow [this documentation](https://allcontributors.org/docs/en/bot/usage).
 
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
 
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [comment]: < ![build](https://github.com/nosqlbench/nosqlbench/workflows/build/badge.svg) >
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.nosqlbench/nosqlbench/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.nosqlbench/nosqlbench)
+[![All Contributors](https://img.shields.io/github/all-contributors/nosqlbench/nosqlbench?color=ee8449&style=flat-square)](#contributors)
 
 
 # NoSQLBench v5


### PR DESCRIPTION
Configuring all-contributors into the repo. Fixes #945.

Pending work for this to work:
- [x] Project/Orgnization owner needs to install the `allcontributors` into the `nosqlbench` repo by following the steps [here](https://allcontributors.org/docs/en/bot/installation)