### PR TITLE
Optimize major performance bottleneck in Pulsar adapter

### DIFF
--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterUtil.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterUtil.java
@@ -483,18 +483,6 @@ public class PulsarAdapterUtil {
     }
 
     ///////
-    // Generate effective key string
-    public static String buildCacheKey(String... keyParts) {
-        // Ignore blank keyPart
-        String joinedKeyStr =
-            Stream.of(keyParts)
-            .filter(s -> !StringUtils.isBlank(s))
-            .collect(Collectors.joining(","));
-
-        return Base64.getEncoder().encodeToString(joinedKeyStr.getBytes());
-    }
-
-    ///////
     // Convert JSON string to a key/value map
     private static final ObjectMapper JACKSON_OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, String>> MAP_TYPE_REF = new TypeReference<>() {};


### PR DESCRIPTION
### Motivation

See #983 and #1005 which targeted the nb4-maintenance branch. This PR ports similar changes to the main branch.

### Modifications

* String operations with enums can become a bottleneck with high throughput. 
  * The optimization is to pre-compute useful data structures when the enum is loaded.
* Caches should be using `computeIfAbsent` to prevent races. 
  * Use an efficient key for the caches. In Java 17, using a `record` as a key is the simplest solution.
* simplity Pulsar SchemaType name mapping to Schema instance
* add caching to Avro schema parsing
* Use UTF8 encoding for reading Avro schema files. It was US_ASCII, which doesn't make sense.
