### PR TITLE
Run builddocs only for pushes to master branch in nosqlbench/nosqlbench

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
   builddocs:
     needs: build
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'nosqlbench/nosqlbench' && github.event_name == 'push' && github.ref_name == 'master' }}
     steps:
 
       - name: set git username

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
   builddocs:
     needs: build
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'nosqlbench/nosqlbench' && github.event_name == 'push' && github.ref_name == 'master' }}
+    if: ${{ github.repository == 'nosqlbench/nosqlbench' && github.event_name == 'push' && github.ref_name == 'main' }}
     steps:
 
       - name: set git username


### PR DESCRIPTION
### Motivation

The builddocs job should only run for pushes to master branch in nosqlbench/nosqlbench repository.

### Modifications

Add proper condition for build job.