### PR TITLE
[kafka-adapter] Add e2e latency metrics

### DIFF
--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
 
 public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, KafkaSpace> implements NBNamedElement {
 
-    private final static Logger logger = LogManager.getLogger("PulsarBaseOpDispenser");
+    private final static Logger logger = LogManager.getLogger("KafkaBaseOpDispenser");
 
     protected final ParsedOp parsedOp;
     protected final KafkaAdapterMetrics kafkaAdapterMetrics;
@@ -135,6 +135,6 @@ public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, Kaf
 
     @Override
     public String getName() {
-        return "MessageConsumerOpDispenser";
+        return "KafkaBaseOpDispenser";
     }
 }

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
@@ -22,11 +22,11 @@ import io.nosqlbench.adapter.kafka.exception.KafkaAdapterInvalidParamException;
 import io.nosqlbench.adapter.kafka.ops.KafkaOp;
 import io.nosqlbench.adapter.kafka.util.KafkaAdapterMetrics;
 import io.nosqlbench.adapter.kafka.util.KafkaAdapterUtil;
+import io.nosqlbench.api.config.NBNamedElement;
 import io.nosqlbench.engine.api.activityimpl.BaseOpDispenser;
 import io.nosqlbench.engine.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.engine.api.templating.ParsedOp;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,7 +35,7 @@ import java.util.*;
 import java.util.function.LongFunction;
 import java.util.function.Predicate;
 
-public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, KafkaSpace> {
+public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, KafkaSpace> implements NBNamedElement {
 
     private final static Logger logger = LogManager.getLogger("PulsarBaseOpDispenser");
 
@@ -69,7 +69,7 @@ public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, Kaf
         this.kafkaSpace = kafkaSpace;
 
         String defaultMetricsPrefix = getDefaultMetricsPrefix(this.parsedOp);
-        this.kafkaAdapterMetrics = new KafkaAdapterMetrics(defaultMetricsPrefix);
+        this.kafkaAdapterMetrics = new KafkaAdapterMetrics(this, defaultMetricsPrefix);
         kafkaAdapterMetrics.initS4JAdapterInstrumentation();
 
         this.asyncAPI =
@@ -131,5 +131,10 @@ public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, Kaf
         logger.info("{}: {}", paramName, stringLongFunction.apply(0));
 
         return stringLongFunction;
+    }
+
+    @Override
+    public String getName() {
+        return "MessageConsumerOpDispenser";
     }
 }

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/ops/OpTimeTrackKafkaConsumer.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/ops/OpTimeTrackKafkaConsumer.java
@@ -116,10 +116,11 @@ public class OpTimeTrackKafkaConsumer extends OpTimeTrackKafkaClient {
                 if (record != null) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(
-                            "Receiving message is successful: [{}] - offset({}), cycle ({})",
+                            "Receiving message is successful: [{}] - offset({}), cycle ({}), e2e_latency_ms({})",
                             printRecvedMsg(record),
                             record.offset(),
-                            cycle);
+                            cycle,
+                            System.currentTimeMillis() - record.timestamp());
                     }
 
                     if (!autoCommitEnabled) {

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/EndToEndStartingTimeSource.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/EndToEndStartingTimeSource.java
@@ -1,0 +1,23 @@
+package io.nosqlbench.adapter.kafka.util;
+
+/*
+ * Copyright (c) 2022 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public enum EndToEndStartingTimeSource {
+    NONE, // no end-to-end latency calculation
+    MESSAGE_PUBLISH_TIME, // use message publish timestamp
+}

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
@@ -32,6 +32,11 @@ public class KafkaAdapterMetrics implements NBNamedElement {
     private Histogram messageSizeHistogram;
     private Timer bindTimer;
     private Timer executeTimer;
+
+    public Histogram getE2eMsgProcLatencyHistogram() {
+        return e2eMsgProcLatencyHistogram;
+    }
+
     // end-to-end latency
     private Histogram e2eMsgProcLatencyHistogram;
     private KafkaBaseOpDispenser kafkaBaseOpDispenser;

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
@@ -17,6 +17,7 @@
 package io.nosqlbench.adapter.kafka.util;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
+import io.nosqlbench.adapter.kafka.dispensers.KafkaBaseOpDispenser;
 import io.nosqlbench.api.config.NBNamedElement;
 import io.nosqlbench.api.engine.metrics.ActivityMetrics;
 import org.apache.logging.log4j.LogManager;
@@ -31,8 +32,12 @@ public class KafkaAdapterMetrics implements NBNamedElement {
     private Histogram messageSizeHistogram;
     private Timer bindTimer;
     private Timer executeTimer;
+    // end-to-end latency
+    private Histogram e2eMsgProcLatencyHistogram;
+    private KafkaBaseOpDispenser kafkaBaseOpDispenser;
 
-    public KafkaAdapterMetrics(String defaultMetricsPrefix) {
+    public KafkaAdapterMetrics(KafkaBaseOpDispenser kafkaBaseOpDispenser, String defaultMetricsPrefix) {
+        this.kafkaBaseOpDispenser = kafkaBaseOpDispenser;
         this.defaultAdapterMetricsPrefix = defaultMetricsPrefix;
     }
 
@@ -59,6 +64,11 @@ public class KafkaAdapterMetrics implements NBNamedElement {
             ActivityMetrics.timer(
                 this,
                 defaultAdapterMetricsPrefix + "execute",
+                ActivityMetrics.DEFAULT_HDRDIGITS);
+        this.e2eMsgProcLatencyHistogram =
+            ActivityMetrics.histogram(
+                kafkaBaseOpDispenser,
+                defaultAdapterMetricsPrefix + "e2e_msg_latency",
                 ActivityMetrics.DEFAULT_HDRDIGITS);
     }
 

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterUtil.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterUtil.java
@@ -41,7 +41,8 @@ public class KafkaAdapterUtil {
     // Valid document level parameters for JMS NB yaml file
     public enum DOC_LEVEL_PARAMS {
         // Blocking message producing or consuming
-        ASYNC_API("async_api");
+        ASYNC_API("async_api"),
+        E2E_STARTING_TIME_SOURCE("e2e_starting_time_source");
         public final String label;
 
         DOC_LEVEL_PARAMS(String label) {

--- a/adapter-kafka/src/main/resources/kafka_consumer.yaml
+++ b/adapter-kafka/src/main/resources/kafka_consumer.yaml
@@ -3,7 +3,8 @@ params:
   # Whether to commit message asynchronously
   # - default: true
   # - only relevant for manual commit
-  async_api: "true"
+#  async_api: "true"
+  e2e_starting_time_source: "message_publish_time"
 
 blocks:
   msg-consume-block:

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/EndToEndStartingTimeSource.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/EndToEndStartingTimeSource.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.adapter.pulsar.util;
 
 /*
- * Copyright (c) 2022 nosqlbench
+ * Copyright (c) 2022-2023 nosqlbench
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Currently, the kafka adapter doensn't support neither e2e latency metrics nor e2e error metrics. These are all defined in the pulsar adapter: https://github.com/nosqlbench/nosqlbench/blob/12f8697e0e27754074eca413451c0707d0663d70/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterMetrics.java#L42-L59.

This aims at integrating the e2e latency metrics.