### PR TITLE
[kafka-adapter] Add e2e error metrics

### DIFF
--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
@@ -15,6 +15,7 @@
  */
 
 package io.nosqlbench.adapter.kafka.util;
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
 import io.nosqlbench.adapter.kafka.dispensers.KafkaBaseOpDispenser;
@@ -32,6 +33,12 @@ public class KafkaAdapterMetrics implements NBNamedElement {
     private Histogram messageSizeHistogram;
     private Timer bindTimer;
     private Timer executeTimer;
+    // - message out of sequence error counter
+    private Counter msgErrOutOfSeqCounter;
+    // - message loss counter
+    private Counter msgErrLossCounter;
+    // - message duplicate error counter
+    private Counter msgErrDuplicateCounter;
 
     public Histogram getE2eMsgProcLatencyHistogram() {
         return e2eMsgProcLatencyHistogram;
@@ -70,11 +77,27 @@ public class KafkaAdapterMetrics implements NBNamedElement {
                 this,
                 defaultAdapterMetricsPrefix + "execute",
                 ActivityMetrics.DEFAULT_HDRDIGITS);
+
+        // End-to-end metrics
+        // Latency
         this.e2eMsgProcLatencyHistogram =
             ActivityMetrics.histogram(
                 kafkaBaseOpDispenser,
                 defaultAdapterMetricsPrefix + "e2e_msg_latency",
                 ActivityMetrics.DEFAULT_HDRDIGITS);
+        // Error metrics
+        this.msgErrOutOfSeqCounter =
+            ActivityMetrics.counter(
+                kafkaBaseOpDispenser,
+                defaultAdapterMetricsPrefix + "err_msg_oos");
+        this.msgErrLossCounter =
+            ActivityMetrics.counter(
+                kafkaBaseOpDispenser,
+                defaultAdapterMetricsPrefix + "err_msg_loss");
+        this.msgErrDuplicateCounter =
+            ActivityMetrics.counter(
+                kafkaBaseOpDispenser,
+                defaultAdapterMetricsPrefix + "err_msg_dup");
     }
 
     public Timer getBindTimer() { return bindTimer; }


### PR DESCRIPTION
Currently, the kafka adapter doensn't support neither e2e latency metrics nor e2e error metrics. These are all defined in the pulsar adapter: https://github.com/nosqlbench/nosqlbench/blob/12f8697e0e27754074eca413451c0707d0663d70/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/PulsarAdapterMetrics.java#L42-L59.

This aims at integrating the e2e error metrics.