### PR TITLE
Refine kafka adapter e2e latency metrics

### DIFF
--- a/adapter-kafka/pom.xml
+++ b/adapter-kafka/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>commons-configuration2</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.nosqlbench</groupId>
+            <artifactId>adapter-pulsar</artifactId>
+            <version>5.17.2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/MessageProducerOpDispenser.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/MessageProducerOpDispenser.java
@@ -66,11 +66,6 @@ public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
                                       LongFunction<String> tgtNameFunc,
                                       KafkaSpace kafkaSpace) {
         super(adapter, op, tgtNameFunc, kafkaSpace);
-        // Doc-level parameter: seq_tracking
-        this.seqTrackingFunc = lookupStaticBoolConfigValueFunc(
-            PulsarAdapterUtil.DOC_LEVEL_PARAMS.SEQ_TRACKING.label, false);
-        this.msgSeqErrSimuTypeSetFunc = getStaticErrSimuTypeSetOpValueFunc();
-
         this.producerClientConfMap.putAll(kafkaSpace.getKafkaClientConf().getProducerConfMap());
         producerClientConfMap.put("bootstrap.servers", kafkaSpace.getBootstrapSvr());
 
@@ -79,6 +74,11 @@ public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
         this.msgHeaderJsonStrFunc = lookupOptionalStrOpValueFunc(MSG_HEADER_OP_PARAM);
         this.msgKeyStrFunc = lookupOptionalStrOpValueFunc(MSG_KEY_OP_PARAM);
         this.msgValueStrFunc = lookupMandtoryStrOpValueFunc(MSG_BODY_OP_PARAM);
+
+        this.msgSeqErrSimuTypeSetFunc = getStaticErrSimuTypeSetOpValueFunc();
+        // Doc-level parameter: seq_tracking
+        this.seqTrackingFunc = lookupStaticBoolConfigValueFunc(
+            PulsarAdapterUtil.DOC_LEVEL_PARAMS.SEQ_TRACKING.label, false);
     }
 
     private String getEffectiveClientId(long cycle) {

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/MessageProducerOpDispenser.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/MessageProducerOpDispenser.java
@@ -22,6 +22,7 @@ import io.nosqlbench.adapter.kafka.ops.KafkaOp;
 import io.nosqlbench.adapter.kafka.ops.OpTimeTrackKafkaClient;
 import io.nosqlbench.adapter.kafka.ops.OpTimeTrackKafkaProducer;
 import io.nosqlbench.adapter.kafka.util.KafkaAdapterUtil;
+import io.nosqlbench.adapter.pulsar.util.PulsarAdapterUtil;
 import io.nosqlbench.engine.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.engine.api.templating.ParsedOp;
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +35,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.LongFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 
 public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
 
@@ -49,12 +58,18 @@ public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
     private final LongFunction<String> msgHeaderJsonStrFunc;
     private final LongFunction<String> msgKeyStrFunc;
     private final LongFunction<String> msgValueStrFunc;
+    protected final LongFunction<Boolean> seqTrackingFunc;
+    protected final LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> msgSeqErrSimuTypeSetFunc;
 
     public MessageProducerOpDispenser(DriverAdapter adapter,
                                       ParsedOp op,
                                       LongFunction<String> tgtNameFunc,
                                       KafkaSpace kafkaSpace) {
         super(adapter, op, tgtNameFunc, kafkaSpace);
+        // Doc-level parameter: seq_tracking
+        this.seqTrackingFunc = lookupStaticBoolConfigValueFunc(
+            PulsarAdapterUtil.DOC_LEVEL_PARAMS.SEQ_TRACKING.label, false);
+        this.msgSeqErrSimuTypeSetFunc = getStaticErrSimuTypeSetOpValueFunc();
 
         this.producerClientConfMap.putAll(kafkaSpace.getKafkaClientConf().getProducerConfMap());
         producerClientConfMap.put("bootstrap.servers", kafkaSpace.getBootstrapSvr());
@@ -126,6 +141,8 @@ public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
                 asyncAPI,
                 transactionEnabled,
                 txnBatchNum,
+                seqTrackingFunc.apply(cycle),
+                msgSeqErrSimuTypeSetFunc.apply(cycle),
                 producer);
             kafkaSpace.addOpTimeTrackKafkaClient(cacheKey, opTimeTrackKafkaClient);
         }
@@ -207,5 +224,29 @@ public class MessageProducerOpDispenser extends KafkaBaseOpDispenser {
             kafkaSpace,
             opTimeTrackKafkaProducer,
             message);
+    }
+
+    protected LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> getStaticErrSimuTypeSetOpValueFunc() {
+        LongFunction<Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE>> setStringLongFunction;
+        setStringLongFunction = (l) ->
+            parsedOp.getOptionalStaticValue(PulsarAdapterUtil.DOC_LEVEL_PARAMS.SEQERR_SIMU.label, String.class)
+                .filter(Predicate.not(String::isEmpty))
+                .map(value -> {
+                    Set<PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE> set = new HashSet<>();
+
+                    if (StringUtils.contains(value,',')) {
+                        set = Arrays.stream(value.split(","))
+                            .map(PulsarAdapterUtil.MSG_SEQ_ERROR_SIMU_TYPE::parseSimuType)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+                    }
+
+                    return set;
+                }).orElse(Collections.emptySet());
+        logger.info(
+            PulsarAdapterUtil.DOC_LEVEL_PARAMS.SEQERR_SIMU.label + ": {}",
+            setStringLongFunction.apply(0));
+        return setStringLongFunction;
     }
 }

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/ops/OpTimeTrackKafkaConsumer.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/ops/OpTimeTrackKafkaConsumer.java
@@ -197,15 +197,18 @@ public class OpTimeTrackKafkaConsumer extends OpTimeTrackKafkaClient {
     }
 
     private void updateE2ELatencyMetric(ConsumerRecord<String, String> record) {
-        long startTimeStamp = 0L;
-        switch (e2eStartingTimeSrc) {
-            case MESSAGE_PUBLISH_TIME:
-                startTimeStamp = record.timestamp();
-                break;
-        }
-        if (startTimeStamp != 0L) {
-            long e2eMsgLatency = System.currentTimeMillis() - startTimeStamp;
-            e2eMsgProcLatencyHistogram.update(e2eMsgLatency);
+        // keep track end-to-end message processing latency
+        if (e2eStartingTimeSrc != EndToEndStartingTimeSource.NONE) {
+            long startTimeStamp = 0L;
+            switch (e2eStartingTimeSrc) {
+                case MESSAGE_PUBLISH_TIME:
+                    startTimeStamp = record.timestamp();
+                    break;
+            }
+            if (startTimeStamp != 0L) {
+                long e2eMsgLatency = System.currentTimeMillis() - startTimeStamp;
+                e2eMsgProcLatencyHistogram.update(e2eMsgLatency);
+            }
         }
     }
 

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/EndToEndStartingTimeSource.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/EndToEndStartingTimeSource.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.adapter.kafka.util;
 
 /*
- * Copyright (c) 2022 nosqlbench
+ * Copyright (c) 2022-2023 nosqlbench
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterMetrics.java
@@ -103,4 +103,28 @@ public class KafkaAdapterMetrics implements NBNamedElement {
     public Timer getBindTimer() { return bindTimer; }
     public Timer getExecuteTimer() { return executeTimer; }
     public Histogram getMessagesizeHistogram() { return messageSizeHistogram; }
+
+    public Counter getMsgErrOutOfSeqCounter() {
+        return msgErrOutOfSeqCounter;
+    }
+
+    public void setMsgErrOutOfSeqCounter(Counter msgErrOutOfSeqCounter) {
+        this.msgErrOutOfSeqCounter = msgErrOutOfSeqCounter;
+    }
+
+    public Counter getMsgErrLossCounter() {
+        return msgErrLossCounter;
+    }
+
+    public void setMsgErrLossCounter(Counter msgErrLossCounter) {
+        this.msgErrLossCounter = msgErrLossCounter;
+    }
+
+    public Counter getMsgErrDuplicateCounter() {
+        return msgErrDuplicateCounter;
+    }
+
+    public void setMsgErrDuplicateCounter(Counter msgErrDuplicateCounter) {
+        this.msgErrDuplicateCounter = msgErrDuplicateCounter;
+    }
 }

--- a/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterUtil.java
+++ b/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/util/KafkaAdapterUtil.java
@@ -42,7 +42,8 @@ public class KafkaAdapterUtil {
     public enum DOC_LEVEL_PARAMS {
         // Blocking message producing or consuming
         ASYNC_API("async_api"),
-        E2E_STARTING_TIME_SOURCE("e2e_starting_time_source");
+        E2E_STARTING_TIME_SOURCE("e2e_starting_time_source"),
+        SEQ_TRACKING("seq_tracking");
         public final String label;
 
         DOC_LEVEL_PARAMS(String label) {

--- a/adapter-kafka/src/main/resources/kafka_consumer.yaml
+++ b/adapter-kafka/src/main/resources/kafka_consumer.yaml
@@ -5,6 +5,10 @@ params:
   # - only relevant for manual commit
 #  async_api: "true"
   e2e_starting_time_source: "message_publish_time"
+  # activates e2e error metrics (message duplication, message loss and out-of-order detection)
+  # it needs to be enabled both on the producer and the consumer
+  # - default: false
+  seq_tracking: "true"
 
 blocks:
   msg-consume-block:

--- a/adapter-kafka/src/main/resources/kafka_producer.yaml
+++ b/adapter-kafka/src/main/resources/kafka_producer.yaml
@@ -9,6 +9,10 @@ params:
   # whether to confirm message send ack. asynchronously
   # - default: true
   async_api: "true"
+  # activates e2e error metrics (message duplication, message loss and out-of-order detection)
+  # it needs to be enabled both on the producer and the consumer
+  # - default: false
+  seq_tracking: "true"
 
 blocks:
   msg-produce-block:

--- a/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/EndToEndStartingTimeSource.java
+++ b/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/util/EndToEndStartingTimeSource.java
@@ -1,7 +1,7 @@
 package io.nosqlbench.adapter.pulsar.util;
 
 /*
- * Copyright (c) 2022-2023 nosqlbench
+ * Copyright (c) 2022 nosqlbench
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a follow-up to remidiate minor shortcomings introduced by https://github.com/nosqlbench/nosqlbench/pull/1127. 

1. fix copyright year in 2 classes
2. add check to allow user to disable e2e latency metrics