### PR TITLE
PR-NB5-Docs Indentation Fix

### DIFF
--- a/virtdata-userlibs/src/main/java/io/nosqlbench/virtdata/userlibs/apps/docsapp/fdocs/FDocCtor.java
+++ b/virtdata-userlibs/src/main/java/io/nosqlbench/virtdata/userlibs/apps/docsapp/fdocs/FDocCtor.java
@@ -43,11 +43,11 @@ public class FDocCtor {
     public String asMarkdown() {
         StringBuilder sb = new StringBuilder();
         // - in->Name(arg1: type1, ...) ->out
-        sb.append("- ").append(in).append(" -> ");
+        sb.append("- `").append(in).append(" -> ");
         sb.append(className).append("(");
         String args = this.args.entrySet().stream().map(e -> e.getValue() + ": " + e.getKey()).collect(Collectors.joining(", "));
         sb.append(args);
-        sb.append(") -> ").append(out).append("\n");
+        sb.append(") -> ").append(out).append("`\n");
 
         if (!ctorJavaDoc.isEmpty()) {
             sb.append("  - *notes:* ").append(ctorJavaDoc).append("\n");


### PR DESCRIPTION
This is in response to issue #1197 

Wrapped culprit generated code with code delimiters that way Zola does not perceive any characters as special characters for indentation.

This fix has been validated by running `export-docs` locally and replacing the `funcref_collections` markdown with the newly generated one that includes the code delimiters. The new file solved the issue.