### PR TITLE
Filter script parameters from activity context

### DIFF
--- a/engine-cli/src/main/resources/scripts/auto/fm.js
+++ b/engine-cli/src/main/resources/scripts/auto/fm.js
@@ -2,6 +2,24 @@
 function printa(arg) { java.lang.System.out.print(arg); }
 //function println(arg) { java.lang.System.out.println(arg); }
 
+const SCRIPT_PARAMS = ["sample_seconds", "latency_percentile", "latency_threshold", "minimum_ratio", "averageof"];
+
+function filterScriptParams(activitydef) {
+    var def = {};
+    for (var p in activitydef) {
+        var isScriptParam = false;
+        for (i in SCRIPT_PARAMS) {
+            if (p == SCRIPT_PARAMS[i]) {
+                isScriptParam = true;
+                break;
+            }
+        }
+        if (!isScriptParam) {
+            def[p] = activitydef[p]
+        }
+    }
+    return def;
+}
 
 if ("TEMPLATE(showhelp,false)" === "true") {
     var helpdata = files.read("docs/findmax.md");
@@ -43,9 +61,9 @@ var baserate = scriptingmetrics.newGauge("findmax.base_rate", 0.0);
 
 //  CREATE SCHEMA
 
-schema_activitydef = params.withDefaults({
+schema_activitydef = filterScriptParams(params.withDefaults({
     type: "diag"
-});
+}));
 schema_activitydef.alias="findmax_schema";
 schema_activitydef.threads="1";
 schema_activitydef.tags="TEMPLATE(schematags,block:\"schema.*\")";
@@ -56,10 +74,10 @@ scenario.run(schema_activitydef);
 //  START ITERATING ACTIVITY
 
 
-activitydef = params.withDefaults({
+activitydef = filterScriptParams(params.withDefaults({
     type: "diag",
     threads: "50"
-});
+}));
 activitydef.alias="findmax";
 activitydef.cycles="1000000000";
 activitydef.recycles="1000000000";

--- a/nbr/src/main/resources/scripts/auto/findmax.js
+++ b/nbr/src/main/resources/scripts/auto/findmax.js
@@ -26,6 +26,27 @@ function printf(args) {
     java.lang.System.out.printf(arguments[0],values);
 }
 
+const SCRIPT_PARAMS = ["profile", "sample_time", "sample_incr", "sample_max", "averageof",
+                       "min_stride", "rate_base", "rate_step", "rate_incr", "testrate_cutoff",
+                       "bestrate_cutoff", "latency_cutoff", "latency_pctile"];
+
+function filterScriptParams(activitydef) {
+    var def = {};
+    for (var p in activitydef) {
+        var isScriptParam = false;
+        for (i in SCRIPT_PARAMS) {
+            if (p == SCRIPT_PARAMS[i]) {
+                isScriptParam = true;
+                break;
+            }
+        }
+        if (!isScriptParam) {
+            def[p] = activitydef[p]
+        }
+    }
+    return def;
+}
+
 if ("TEMPLATE(showhelp,false)" === "true") {
     var helpdata = files.read("docs/findmax.md");
     printf(helpdata);
@@ -141,10 +162,10 @@ var driver = "TEMPLATE(driver,cql)";
 var yaml_file = "TEMPLATE(yaml_file,cql-iot)";
 
 // //  CREATE SCHEMA
-// schema_activitydef = params.withDefaults({
+// schema_activitydef = filterScriptParams(params.withDefaults({
 //     driver: driver,
 //     yaml: yaml_file
-// });
+// }));
 //
 // schema_activitydef.alias = "findmax_schema";
 // schema_activitydef.threads = "1";
@@ -154,12 +175,12 @@ var yaml_file = "TEMPLATE(yaml_file,cql-iot)";
 // scenario.run(schema_activitydef);
 
 //  START ITERATING ACTIVITY
-activitydef = params.withDefaults({
+activitydef = filterScriptParams(params.withDefaults({
     driver: driver,
     yaml: yaml_file,
     threads: "auto",
     cyclerate: "1.0:1.1"
-});
+}));
 
 activitydef.alias = "findmax";
 activitydef.cycles = "1000000000";

--- a/nbr/src/main/resources/scripts/auto/optimo.js
+++ b/nbr/src/main/resources/scripts/auto/optimo.js
@@ -16,6 +16,26 @@ function printf(args) {
     java.lang.System.out.printf(arguments[0], values);
 }
 
+const SCRIPT_PARAMS = ["sample_time", "sample_incr", "sample_max", "min_stride", "averageof",
+                       "latency_cutoff", "latency_pctile"];
+
+function filterScriptParams(activitydef) {
+    var def = {};
+    for (var p in activitydef) {
+        var isScriptParam = false;
+        for (i in SCRIPT_PARAMS) {
+            if (p == SCRIPT_PARAMS[i]) {
+                isScriptParam = true;
+                break;
+            }
+        }
+        if (!isScriptParam) {
+            def[p] = activitydef[p]
+        }
+    }
+    return def;
+}
+
 function as_js(ref) {
     if (JSON.stringify(ref)) {
         return ref;
@@ -106,10 +126,10 @@ let activity_type = "TEMPLATE(activity_type,cql)";
 let yaml_file = "TEMPLATE(yaml_file,cql-iot)";
 
 //  CREATE SCHEMA
-schema_activitydef = params.withDefaults({
+schema_activitydef = filterScriptParams(params.withDefaults({
     type: activity_type,
     yaml: yaml_file
-});
+}));
 schema_activitydef.alias = "optimo_schema";
 schema_activitydef.threads = "1";
 schema_activitydef.tags = "TEMPLATE(schematags,block:'schema.*')";
@@ -119,13 +139,13 @@ print("Creating schema with schematags:" + schema_activitydef.tags);
 scenario.run(schema_activitydef);
 
 //  START ITERATING ACTIVITY
-activitydef = params.withDefaults({
+activitydef = filterScriptParams(params.withDefaults({
     type: activity_type,
     yaml: yaml_file,
     threads: "50",
     async: 10,
     speculative: "none"
-});
+}));
 activitydef.alias = "optimo";
 activitydef.cycles = "1000000000";
 activitydef.recycles = "1000000000";

--- a/nbr/src/main/resources/scripts/auto/stepup.js
+++ b/nbr/src/main/resources/scripts/auto/stepup.js
@@ -32,6 +32,25 @@ function printf(args) {
     java.lang.System.out.printf(arguments[0], values);
 }
 
+const SCRIPT_PARAMS = ["sample_seconds", "max_rate", "rate_step"];
+
+function filterScriptParams(activitydef) {
+    var def = {};
+    for (var p in activitydef) {
+        var isScriptParam = false;
+        for (i in SCRIPT_PARAMS) {
+            if (p == SCRIPT_PARAMS[i]) {
+                isScriptParam = true;
+                break;
+            }
+        }
+        if (!isScriptParam) {
+            def[p] = activitydef[p]
+        }
+    }
+    return def;
+}
+
 var workload = "TEMPLATE(workload,UNSPECIFIED)";
 if (workload=="UNSPECIFIED") {
  print("workload was unspecified. Please set workload and try again.");
@@ -50,14 +69,14 @@ printf("max_rate=%d\n", max_rate);
 
 var rate_step = 10000;
 rate_step = 0 + TEMPLATE(rate_step,rate_step);
-printf("rate_increment=%d\n", rate_step);
+printf("rate_step=%d\n", rate_step);
 
 var driver = "TEMPLATE(driver,diag)"
 printf("driver=%s\n",driver);
 
 
 print("starting activity for stepup analysis");
-var activitydef = params.withDefaults({
+var activitydef = filterScriptParams(params.withDefaults({
     'alias': 'stepup',
     'driver': driver,
     'tags':'any(block:main.*,block:main)',
@@ -65,7 +84,7 @@ var activitydef = params.withDefaults({
     'cycles': '1t',
     'stride': '1000',
     'striderate': '1:1.05:restart'
-});
+}));
 
 var csvlogger = csvoutput.open('stepup_metrics/stepup_rates.csv', 'time', 'workload', 'rate', 'ops')
 var csvhistologger=csvmetrics.log("stepup_metrics");


### PR DESCRIPTION
Found while using a variant of `stepup.js`. When using `params.withDefaults` in a scenario script, all parameters given on the command line are passed into the activity context. This can cause conflicts with the parameter checking, resulting in errors similar to:
```
javax.script.ScriptException: io.nosqlbench.api.errors.BasicError: Unknown config parameter 'rate_step' in config model while configuring StandardActivity, possible parameter names are
```

This change introduces the `filterScriptParams` function to scenario scripts which use `params.withDefaults`. I've included `SCRIPT_PARAMS` for each script, but have only read the scripts to judge what those parameters are.

`filterScriptParams` was tested against the aformentioned variant of `stepup.js` and shown to resolve the error seen.