### PR TITLE
unbreak HashRange width with inappropriate ctor call

### DIFF
--- a/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_int/HashRange.java
+++ b/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_int/HashRange.java
@@ -35,7 +35,8 @@ public class HashRange implements LongToIntFunction {
 
     @Example({"HashRange(32L)","map the input to a number in the range 0-31, inclusive, of type int"})
     public HashRange(int width) {
-        this(0,width);
+        this.minValue=0;
+        this.width=width;
     }
 
     @Example({"HashRange(35L,39L)","map the input to a number in the range 35-38, inclusive, of type int"})

--- a/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashRange.java
+++ b/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/from_long/to_long/HashRange.java
@@ -41,7 +41,8 @@ public class HashRange implements LongUnaryOperator {
     private final Hash hash = new Hash();
 
     public HashRange(long width) {
-        this(0L,width);
+        this.minValue=0L;
+        this.width=width;
     }
 
     public HashRange(long minValue, long maxValue) {

--- a/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/unary_int/HashRange.java
+++ b/virtdata-lib-basics/src/main/java/io/nosqlbench/virtdata/library/basics/shared/unary_int/HashRange.java
@@ -32,7 +32,8 @@ public class HashRange implements IntUnaryOperator {
     private final Hash hash = new Hash();
 
     public HashRange(int width) {
-        this(0,width);
+        this.minValue=0;
+        this.width=width;
     }
 
     public HashRange(int minValue, int maxValue) {


### PR DESCRIPTION
This should fix the broken tests, as the previous ctor changes were incorrect