### PR TITLE
PromPushReporter Configure to Use SSL and BearerToken

### DIFF
--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
@@ -218,6 +218,7 @@ public class NBCLI implements Function<String[], Integer>, NBLabeledElement {
         final String dockerMetricsAt = globalOptions.wantsDockerMetricsAt();
         String reportGraphiteTo = globalOptions.wantsReportGraphiteTo();
         String annotatorsConfig = globalOptions.getAnnotatorsConfig();
+        String promPushConfig = globalOptions.getPromPushConfig();
         final String reportPromPushTo = globalOptions.wantsReportPromPushTo();
 
 
@@ -416,7 +417,7 @@ public class NBCLI implements Function<String[], Integer>, NBLabeledElement {
             final MetricReporters reporters = MetricReporters.getInstance();
             reporters.addRegistry("workloads", ActivityMetrics.getMetricRegistry());
 
-            if (null != reportPromPushTo) reporters.addPromPush(reportPromPushTo, options.wantsMetricsPrefix());
+            if (null != reportPromPushTo) reporters.addPromPush(reportPromPushTo, options.wantsMetricsPrefix(), promPushConfig);
             if (null != reportGraphiteTo) reporters.addGraphite(reportGraphiteTo, options.wantsMetricsPrefix());
             if (null != options.wantsReportCsvTo())
                 reporters.addCSVReporter(options.wantsReportCsvTo(), options.wantsMetricsPrefix());

--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
@@ -53,6 +53,7 @@ public class NBCLIOptions {
     private static final String METRICS_PREFIX = "--metrics-prefix";
     private static final String ANNOTATE_EVENTS = "--annotate";
     private static final String ANNOTATORS_CONFIG = "--annotators";
+    private static final String PROMPUSH_CONFIG = "--prompush";
 
     // Enabled if the TERM env var is provided
     private static final String ANSI = "--ansi";
@@ -184,6 +185,7 @@ public class NBCLIOptions {
     private String[] annotateEvents = {"ALL"};
     private String dockerMetricsHost;
     private String annotatorsConfig = "";
+    private String promPushConfig = "";
     private String statedirs = NBStatePath.NB_STATEDIR_PATHS;
     private Path statepath;
     private final String hdrForChartFileName = NBCLIOptions.DEFAULT_CHART_HDR_LOG_NAME;
@@ -206,6 +208,10 @@ public class NBCLIOptions {
 
     public String getAnnotatorsConfig() {
         return this.annotatorsConfig;
+    }
+
+    public String getPromPushConfig() {
+        return this.promPushConfig;
     }
 
     public NBLabels getLabelMap() {
@@ -375,6 +381,10 @@ public class NBCLIOptions {
                 case NBCLIOptions.REPORT_PROMPUSH_TO:
                     arglist.removeFirst();
                     this.reportPromPushTo = arglist.removeFirst();
+                    break;
+                case NBCLIOptions.PROMPUSH_CONFIG:
+                    arglist.removeFirst();
+                    promPushConfig = this.readWordOrThrow(arglist, "prompush config");
                     break;
                 case NBCLIOptions.GRAPHITE_LOG_LEVEL:
                     arglist.removeFirst();

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/metrics/MetricReporters.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/metrics/MetricReporters.java
@@ -115,7 +115,7 @@ public class MetricReporters implements Shutdownable {
         return this;
     }
 
-    public MetricReporters addPromPush(final String reportPromPushTo, final String prefix) {
+    public MetricReporters addPromPush(final String reportPromPushTo, final String prefix, final String config) {
 
         logger.debug(() -> "Adding prompush reporter to " + reportPromPushTo + " with prefix label to " + prefix);
 
@@ -131,7 +131,8 @@ public class MetricReporters implements Shutdownable {
                     "prompush",
                     MetricFilter.ALL,
                     TimeUnit.SECONDS,
-                    TimeUnit.NANOSECONDS
+                    TimeUnit.NANOSECONDS,
+                    config
                     );
             scheduledReporters.add(promPushReporter);
         }

--- a/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/PromPushKeyFileReader.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/PromPushKeyFileReader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nosqlbench.api.engine.metrics.reporters;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+public class PromPushKeyFileReader implements Supplier<String> {
+    private final static Logger logger = LogManager.getLogger("METRICS" );
+
+    private final Path keyfilePath;
+
+    public PromPushKeyFileReader(Path path) {
+        this.keyfilePath = path;
+    }
+
+    public PromPushKeyFileReader(String sourcePath) {
+        this.keyfilePath = Path.of(sourcePath);
+    }
+
+    @Override
+    public String get() {
+        if (!Files.exists(keyfilePath)) {
+            logger.warn("apikeyfile does not exist at '" + keyfilePath);
+            return null;
+        } else {
+            try {
+                String apikey = Files.readString(keyfilePath, StandardCharsets.UTF_8);
+                apikey = apikey.trim();
+                return apikey;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/PromPushReporter.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/PromPushReporter.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,11 +65,18 @@ public class PromPushReporter extends ScheduledReporter implements NBConfigurabl
         needsAuth = false;
         ConfigLoader loader = new ConfigLoader();
         List<Map> configs = loader.load(config, Map.class);
+        NBConfigModel cm = this.getConfigModel();
         if (configs != null) {
+            logger.info("PromPushReporter process configuration: %s", config);
             for (Map cmap : configs) {
-                NBConfiguration cfg = this.getConfigModel().apply(cmap);
+                NBConfiguration cfg = cm.apply(cmap);
                 this.applyConfig(cfg);
             }
+        } else {
+            logger.info("PromPushReporter default configuration");
+            HashMap<String,String> junk = new HashMap<>(Map.of());
+            NBConfiguration cfg = cm.apply(junk);
+            this.applyConfig(cfg);
         }
     }
 
@@ -90,7 +98,7 @@ public class PromPushReporter extends ScheduledReporter implements NBConfigurabl
         bearerToken = null;
         if (optionalApikeyfile.isPresent()) {
             keyfilePath = optionalApikeyfile.map(Path::of).orElseThrow();
-            PromPushReporter.logger.info("Reading Bearer Token from %s", keyfilePath);
+            logger.info("Reading Bearer Token from %s", keyfilePath);
             PromPushKeyFileReader keyfile = new PromPushKeyFileReader(keyfilePath);
             bearerToken = "Bearer " + keyfile.get();
         } else if (optionalApikey.isPresent()) {


### PR DESCRIPTION
Fixes #1482 

This adds a `--prompush` optional configuration. The processing allows configuration of a Bearer token in the file `~/.nosqlbench/prompush/prompush_apikey`