### PR TITLE
Jshook/filecache

### DIFF
--- a/adapter-cqld4/src/main/java/io/nosqlbench/engine/extensions/vectormath/VectorMath.java
+++ b/adapter-cqld4/src/main/java/io/nosqlbench/engine/extensions/vectormath/VectorMath.java
@@ -31,7 +31,7 @@ public class VectorMath {
         return rows.stream().map(r -> r.getString(fieldName)).toArray(String[]::new);
     }
 
-    public static long[] stringArrayAsALongArray(String[] strings) {
+    public static long[] stringArrayAsLongArray(String[] strings) {
         long[] longs = new long[strings.length];
         for (int i = 0; i < longs.length; i++) {
             longs[i]=Long.parseLong(strings[i]);

--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
@@ -22,8 +22,7 @@ import io.nosqlbench.api.annotations.Annotation;
 import io.nosqlbench.api.annotations.Layer;
 import io.nosqlbench.api.config.NBLabeledElement;
 import io.nosqlbench.api.config.NBLabels;
-import io.nosqlbench.api.content.Content;
-import io.nosqlbench.api.content.NBIO;
+import io.nosqlbench.api.content.*;
 import io.nosqlbench.api.engine.metrics.ActivityMetrics;
 import io.nosqlbench.api.errors.BasicError;
 import io.nosqlbench.api.logging.NBLogLevel;
@@ -210,6 +209,9 @@ public class NBCLI implements Function<String[], Integer>, NBLabeledElement {
             }
         }
 
+        if (globalOptions.getFilecacheExpiry()>0) {
+            NBIO.addContentResolver(new URIResolverCache(ResolverForURL.INSTANCE,globalOptions.getFileCachePattern(), globalOptions.getFilecacheExpiry()));
+        }
 
         final boolean dockerMetrics = globalOptions.wantsDockerMetrics();
         final String dockerMetricsAt = globalOptions.wantsDockerMetricsAt();

--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
@@ -103,7 +103,6 @@ public class NBCLIOptions {
     private static final String DASH_VVV_TRACE = "-vvv";
     private static final String REPORT_INTERVAL = "--report-interval";
     private static final String REPORT_GRAPHITE_TO = "--report-graphite-to";
-
     private static final String REPORT_PROMPUSH_TO = "--report-prompush-to";
     private static final String GRAPHITE_LOG_LEVEL = "--graphite-log-level";
     private static final String REPORT_CSV_TO = "--report-csv-to";
@@ -134,7 +133,8 @@ public class NBCLIOptions {
 
     //    private static final String DEFAULT_CONSOLE_LOGGING_PATTERN = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n";
 
-
+    private static final String FILECACHE_PATTERN = "--filecache-pattern";
+    private static final String FILECACHE_EXPIRY = "--filecache-expiry";
     private NBLabels labels = NBLabels.forKV();
     private final List<Cmd> cmdList = new ArrayList<>();
     private int logsMax;
@@ -197,6 +197,8 @@ public class NBCLIOptions {
     private boolean wantsListCommands;
     private boolean wantsListApps;
     private boolean dedicatedVerificationLogger;
+    private String filecachePattern = ".*";
+    private long filecacheExpiry = 10L;
 
     public boolean isWantsListApps() {
         return this.wantsListApps;
@@ -630,6 +632,14 @@ public class NBCLIOptions {
                     arglist.removeFirst();
                     this.wantsToCopyWorkload = this.readWordOrThrow(arglist, "workload to copy");
                     break;
+                case FILECACHE_PATTERN:
+                    arglist.removeFirst();
+                    this.filecachePattern = this.readWordOrThrow(arglist, "filecache regex pattern");
+                    break;
+                case FILECACHE_EXPIRY:
+                    arglist.removeFirst();
+                    this.filecacheExpiry = Long.parseLong(this.readWordOrThrow(arglist,"filecache expiry seconds"));
+                    break;
                 default:
                     nonincludes.addLast(arglist.removeFirst());
             }
@@ -908,6 +918,14 @@ public class NBCLIOptions {
 
     public String getDockerPromTag() {
         return this.docker_prom_tag;
+    }
+
+    public long getFilecacheExpiry() {
+        return filecacheExpiry;
+    }
+
+    public String getFileCachePattern() {
+        return filecachePattern;
     }
 
     public static class LoggerConfigData {

--- a/nb-api/src/main/java/io/nosqlbench/api/content/ResolverForURL.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/content/ResolverForURL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 nosqlbench
+ * Copyright (c) 2022-2023 nosqlbench
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.List;
 
 public class ResolverForURL implements ContentResolver {
 
-    public static final ContentResolver INSTANCE = new ResolverForURL();
+    public static final ResolverForURL INSTANCE = new ResolverForURL();
     private final static Logger logger = LogManager.getLogger(ResolverForURL.class);
 
     @Override

--- a/nb-api/src/main/java/io/nosqlbench/api/content/URIResolver.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/content/URIResolver.java
@@ -21,6 +21,7 @@ import io.nosqlbench.api.errors.BasicError;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,13 +32,13 @@ import java.util.Optional;
  */
 public class URIResolver implements ContentResolver {
 
-    private List<ContentResolver> loaders = new ArrayList<>();
+    private LinkedList<ContentResolver> loaders = new LinkedList<>();
 
-    private static final List<ContentResolver> EVERYWHERE = List.of(
+    private static final LinkedList<ContentResolver> EVERYWHERE = new LinkedList<>(List.of(
         ResolverForURL.INSTANCE,
         ResolverForFilesystem.INSTANCE,
         ResolverForClasspath.INSTANCE
-    );
+    ));
 
     private List<String> extensions;
     private List<Path> extraPaths;
@@ -154,6 +155,10 @@ public class URIResolver implements ContentResolver {
             return null;
         }
         throw new BasicError("Error while loading content '" + candidatePath + "', only one is allowed, but " + contents.size() + " were found");
+    }
+
+    public void prepend(ContentResolver resolver) {
+        this.loaders.addFirst(resolver);
     }
 
     public String toString() {

--- a/nb-api/src/main/java/io/nosqlbench/api/content/URIResolverCache.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/content/URIResolverCache.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nosqlbench.api.content;
+
+import io.nosqlbench.api.errors.BasicError;
+import io.nosqlbench.api.system.NBStatePath;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class URIResolverCache implements ContentResolver {
+
+    public final static Logger logger = LogManager.getLogger(URIResolverCache.class);
+
+    private final Path cachedir;
+    private final ResolverForURL internalResolver;
+    private final long expirySeconds;
+    private final Pattern matcher;
+
+    public URIResolverCache(ResolverForURL resolver) {
+        this(resolver,Pattern.compile(".+\\..+").pattern(),Long.MAX_VALUE);
+    }
+    public URIResolverCache(ResolverForURL resolver, String matcher, long expirySeconds) {
+        this.expirySeconds=expirySeconds;
+        this.matcher = Pattern.compile(matcher);
+        this.internalResolver = resolver;
+        cachedir = NBStatePath.initialize().resolve("filecache");
+
+        if (!Files.exists(cachedir)) try {
+            Files.createDirectories(
+                cachedir,
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwx---"))
+            );
+            logger.debug(() -> "Created remote file cache at " + cachedir);
+        } catch (final IOException e) {
+            throw new BasicError("Could not create state directory at '" + cachedir + "': " + e.getMessage());
+        }
+    }
+
+    @Override
+    public List<Content<?>> resolve(URI uri) {
+        if (!matcher.matcher(uri.toString()).matches()) {
+            logger.debug(() -> "bypassing file cache for " + uri + " since it does not match pattern '" + matcher.pattern() + "'");
+            return internalResolver.resolve(uri);
+        }
+
+        String path = uri.getPath();
+        String[] pathParts = path.split("/");
+        Path cachedAt = cachedir.resolve(Path.of(pathParts[pathParts.length-1]));
+        if (Files.exists(cachedAt) && freshOrRefresh(cachedAt)) {
+            logger.debug(() -> "returning cached file from '" + cachedAt +"'");
+            return List.of(new PathContent(cachedAt));
+        }
+
+        List<Content<?>> loaded = internalResolver.resolve(uri);
+        if (loaded.size()!=1) {
+            throw new RuntimeException("Found " + loaded.size() + " results when loading " + uri);
+        }
+        Content<?> found = loaded.get(0);
+        try {
+            if (Files.exists(cachedAt)) {
+                Files.delete(cachedAt);
+            }
+            Files.write(cachedAt,found.asString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save file in cache: " + e, e);
+        }
+        logger.info("Cached and served '" + uri + "' as '" + cachedAt +"'");
+        return List.of(new PathContent(cachedAt));
+    }
+
+    private boolean freshOrRefresh(Path cachedAt) {
+        try {
+            FileTime lastModified = Files.getLastModifiedTime(cachedAt);
+            if (lastModified.toMillis() +(expirySeconds*1000)> System.currentTimeMillis()) {
+                return false;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    @Override
+    public List<Path> resolveDirectory(URI uri) {
+        return null;
+    }
+}

--- a/nb-api/src/test/java/io/nosqlbench/api/content/URIResolverCacheTest.java
+++ b/nb-api/src/test/java/io/nosqlbench/api/content/URIResolverCacheTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nosqlbench.api.content;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+class URIResolverCacheTest {
+
+    @Disabled
+    @Test
+    public void cacheBasics() {
+        ResolverForURL resolver1 = ResolverForURL.INSTANCE;
+        URIResolverCache caching = new URIResolverCache(resolver1);
+        List<Content<?>> content = caching.resolve(URI.create("https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"));
+    }
+}


### PR DESCRIPTION
fixes #1502 

This allows us to reference urls directly and have them cached locally.
Caveat, this needs to be made safer for concurrent or episodic access patterns, for example when a file is being accessed in mmap mode and another async activity accesses it after the expiry.

        # 10 seconds allows local behavior as before, but re-fetches each start
        # this needs to be improved and made clear for users to avoid Heisenbugs
        --filecache-expiry 10
        # match all patterns by default
        --filecache-pattern ".*"
