### PR TITLE
Address issue #1562 and fix a possible metrics naming issue (for Prometheus/Victoria integration)

### DIFF
--- a/engine-api/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
+++ b/engine-api/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
@@ -52,6 +52,7 @@ import io.nosqlbench.adapters.api.activityimpl.uniform.decorators.SyntheticOpTem
 import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.Op;
 import io.nosqlbench.adapters.api.templating.CommandTemplate;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.engine.api.scenarios.NBCLIScenarioParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -109,7 +110,7 @@ public class SimpleActivity implements Activity {
                     "yaml"
             );
             if (workloadOpt.isPresent()) {
-                activityDef.getParams().set("alias", workloadOpt.get());
+                activityDef.getParams().set("alias", NBCLIScenarioParser.sanitize(workloadOpt.get()));
             } else {
                 activityDef.getParams().set("alias",
                         activityDef.getActivityType().toUpperCase(Locale.ROOT)

--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
@@ -142,19 +142,6 @@ public class NBCLI implements Function<String[], Integer>, NBLabeledElement {
         }
     }
 
-    public static String sanitize(String word) {
-        String sanitized = word;
-        sanitized = sanitized.replaceAll("\\..+$", "");
-        String shortened = sanitized;
-        sanitized = sanitized.replaceAll("-","_");
-        sanitized = sanitized.replaceAll("[^a-zA-Z0-9_]+", "");
-
-        if (!shortened.equals(sanitized)) {
-            logger.warn("The identifier or value '" + shortened + "' was sanitized to '" + sanitized + "' to be compatible with monitoring systems. You should probably change this to make diagnostics easier.");
-        }
-        return sanitized;
-    }
-
     public Integer applyDirect(final String[] args) {
 
         // Initial logging config covers only command line parsing

--- a/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
+++ b/engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
@@ -157,7 +157,7 @@ public class NBCLIOptions {
     private int reportInterval = 10;
     private String metricsPrefix = "nosqlbench";
     private String wantsMetricsForActivity;
-    private String sessionName = "SESSIONCODE";
+    private String sessionName;
     //    private String sessionName = "scenario_%tY%tm%td_%tH%tM%tS_%tL";
     private boolean showScript;
     private NBLogLevel consoleLevel = NBLogLevel.WARN;

--- a/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioParserTest.java
+++ b/engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioParserTest.java
@@ -94,7 +94,7 @@ public class NBCLIScenarioParserTest {
         assertThat(cmds.size()).isEqualTo(1);
         assertThat(cmds.get(0).getArg("driver")).isEqualTo("stdout");
         assertThat(cmds.get(0).getArg("cycles")).isEqualTo("10");
-        assertThat(cmds.get(0).getArg("workload")).isEqualTo("scenario-test");
+        assertThat(cmds.get(0).getArg("workload")).endsWith("scenario-test.yaml");
     }
 
     @Test
@@ -102,13 +102,14 @@ public class NBCLIScenarioParserTest {
         NBCLIOptions opts = new NBCLIOptions(new String[]{"scenario-test", "template-test", "cycles-test=20"});
         List<Cmd> cmds = opts.getCommands();
         assertThat(cmds.size()).isEqualTo(1);
+        assertThat(cmds.get(0).getArg("workload")).endsWith("scenario-test.yaml");
+        cmds.get(0).getParams().remove("workload");
         assertThat(cmds.get(0).getParams()).isEqualTo(Map.of(
                 "alias", "with_template",
                 "cycles", "20",
                 "cycles-test", "20",
                 "driver", "stdout",
-                "labels","workload:$scenario_test",
-                "workload", "scenario-test"
+                "labels","workload:$scenario_test"
         ));
     }
 
@@ -117,13 +118,14 @@ public class NBCLIScenarioParserTest {
         NBCLIOptions opts = new NBCLIOptions(new String[]{"scenario-test", "schema-only", "cycles-test=20"});
         List<Cmd> cmds = opts.getCommands();
         assertThat(cmds.size()).isEqualTo(1);
+        assertThat(cmds.get(0).getArg("workload")).endsWith("scenario-test.yaml");
+        cmds.get(0).getParams().remove("workload");
         assertThat(cmds.get(0).getParams()).isEqualTo(Map.of(
                 "alias", "schema",
                 "cycles-test", "20",
                 "driver", "stdout",
                 "labels","workload:$scenario_test",
-                "tags", "block:\"schema.*\"",
-                "workload", "scenario-test"
+                "tags", "block:\"schema.*\""
         ));
         NBCLIOptions opts1 = new NBCLIOptions(new String[]{"scenario-test", "schema-only", "doundef=20"});
         List<Cmd> cmds1 = opts1.getCommands();
@@ -168,13 +170,14 @@ public class NBCLIScenarioParserTest {
         NBCLIOptions opts = new NBCLIOptions(new String[]{"scenario-test", "schema-only", "cycles-test=20"});
         List<Cmd> cmds = opts.getCommands();
         assertThat(cmds.size()).isEqualTo(1);
+        assertThat(cmds.get(0).getArg("workload")).endsWith("scenario-test.yaml");
+        cmds.get(0).getParams().remove("workload");
         assertThat(cmds.get(0).getParams()).isEqualTo(Map.of(
                 "alias", "schema",
                 "cycles-test", "20",
                 "driver", "stdout",
                 "labels","workload:$scenario_test",
-                "tags", "block:\"schema.*\"",
-                "workload", "scenario-test"
+                "tags", "block:\"schema.*\""
         ));
         NBCLIOptions opts1 = new NBCLIOptions(new String[]{"local/example-scenarios", "namedsteps.one", "testparam1=testvalue2"});
         List<Cmd> cmds1 = opts1.getCommands();

--- a/nb-api/src/main/java/io/nosqlbench/api/metadata/SessionNamer.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/metadata/SessionNamer.java
@@ -17,8 +17,13 @@
 package io.nosqlbench.api.metadata;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 public class SessionNamer {
+
+    public static UUID getUUID() {
+        return UUID.randomUUID();
+    }
 
     public static String format(String sessionName, long sessionTimeMillis) {
         String nameTemplate = sessionName;


### PR DESCRIPTION
1. **session identifier**: use a random UUID string as the default value unless being explicitly overridden by the CLI "--session-name" option
2. for named scenario, if an alias is explicitly specified, make sure it is sanitized properly
3. for non-named scenario, currently the fullworkload file path will be part of the metrics names, sanitize the file path before adding them in the metrics names