### PR TITLE
Mwolters/1611

### DIFF
--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
@@ -16,16 +16,14 @@
 
 package io.nosqlbench.engine.core.lifecycle.session;
 
-import com.codahale.metrics.Counting;
-import com.codahale.metrics.Gauge;
 import io.nosqlbench.api.engine.metrics.instruments.NBFunctionGauge;
 import io.nosqlbench.api.engine.metrics.instruments.NBMetric;
 import io.nosqlbench.api.engine.metrics.instruments.NBMetricGauge;
 import io.nosqlbench.api.engine.metrics.reporters.ConsoleReporter;
 import io.nosqlbench.api.labels.NBLabeledElement;
 import io.nosqlbench.api.labels.NBLabels;
-import io.nosqlbench.components.NBComponent;
 import io.nosqlbench.components.NBBaseComponent;
+import io.nosqlbench.components.NBComponent;
 import io.nosqlbench.components.NBComponentSubScope;
 import io.nosqlbench.components.NBCreators;
 import io.nosqlbench.components.decorators.NBTokenWords;
@@ -40,11 +38,9 @@ import io.nosqlbench.engine.core.lifecycle.scenario.execution.NBScenario;
 import io.nosqlbench.engine.core.lifecycle.scenario.execution.ScenariosExecutor;
 import io.nosqlbench.engine.core.lifecycle.scenario.execution.ScenariosResults;
 import io.nosqlbench.engine.core.lifecycle.scenario.script.NBScriptedScenario;
-import io.nosqlbench.engine.core.metrics.NBMetricsSummary;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
@@ -115,6 +115,7 @@ public class NBSession extends NBBaseComponent implements Function<List<Cmd>, Ex
                 NBCLIErrorHandler.handle(exception, true);
                 System.err.println(exception.getMessage()); // TODO: make this consistent with ConsoleLogging sequencing
             }
+            metricsBuffer.printMetricSummary(this);
             results.output(scenariosResults.getExecutionSummary());
             results.ok();
         }

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/NBSession.java
@@ -267,19 +267,6 @@ public class NBSession extends NBBaseComponent implements Function<List<Cmd>, Ex
     @Override
     public void reportExecutionMetric(NBMetric metric) {
         summaryMetrics.add(metric);
-//        StringBuilder metricSummary = new StringBuilder();
-//        if (metric instanceof Counting counting) {
-//            final long count = counting.getCount();
-//            if (0 < count) {
-//                NBMetricsSummary.summarize(metricSummary, metric.getLabels().linearizeAsMetrics(), metric);
-//            }
-//        } else if (metric instanceof Gauge<?> gauge) {
-//            final Object value = gauge.getValue();
-//            if (value instanceof Number n) if (0 != n.doubleValue()) {
-//                NBMetricsSummary.summarize(metricSummary, metric.getLabels().linearizeAsMetrics(), metric);
-//            }
-//        }
-//        metricsSummary.append(metricSummary).append("\n");
     }
 
 }

--- a/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/ConsoleReporter.java
+++ b/nb-api/src/main/java/io/nosqlbench/api/engine/metrics/reporters/ConsoleReporter.java
@@ -221,4 +221,27 @@ public class ConsoleReporter extends PeriodicTaskComponent {
     protected double convertDuration(double duration) {
         return duration / durationFactor;
     }
+
+    public void reportOnce(List<NBMetric> summaryMetrics) {
+        List<NBMetricGauge> gauges = new ArrayList<>();
+        List<NBMetricCounter> counters = new ArrayList<>();
+        List<NBMetricHistogram> histograms = new ArrayList<>();
+        List<NBMetricMeter> meters = new ArrayList<>();
+        List<NBMetricTimer> timers = new ArrayList<>();
+        for (NBMetric metric : summaryMetrics) {
+            if (metric instanceof NBMetricGauge) {
+                gauges.add((NBMetricGauge) metric);
+            } if (metric instanceof NBMetricCounter) {
+                counters.add((NBMetricCounter) metric);
+            } if (metric instanceof NBMetricHistogram) {
+                histograms.add((NBMetricHistogram) metric);
+            } if (metric instanceof NBMetricMeter) {
+                meters.add((NBMetricMeter) metric);
+            } if (metric instanceof NBMetricTimer) {
+                timers.add((NBMetricTimer) metric);
+            }
+        }
+        report(gauges, counters, histograms, meters, timers);
+    }
+
 }

--- a/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
@@ -130,7 +130,7 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
         if (parent != null) {
             parent.reportExecutionMetric(m);
         } else {
-            logger.debug("buffering metric " + m.toString() + " for final report");
+            logger.warn(() -> "Component " + this.toString() + " has a non-session null parent component");
         }
     }
 

--- a/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
@@ -111,6 +111,7 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
             for (NBComponent child : children) {
                 child.close();
             }
+            reportMetrics();
             teardown();
         } catch (Exception e) {
             logger.error(e);
@@ -119,6 +120,21 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
             if (parent != null) {
                 parent.detachChild(this);
             }
+        }
+    }
+
+    private void reportMetrics() {
+        this.getComponentMetrics().forEach(m -> {
+            logger.debug("reporting metric " + m.toString());
+            reportExecutionMetric(m);
+        });
+    }
+
+    public void reportExecutionMetric(NBMetric m) {
+        if (parent != null) {
+            parent.reportExecutionMetric(m);
+        } else {
+            logger.debug("buffering metric " + m.toString() + " for final report");
         }
     }
 

--- a/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
@@ -101,6 +101,10 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
     @Override
     public void beforeDetach() {
         logger.debug("before detach " + description());
+        this.getComponentMetrics().forEach(m -> {
+            logger.debug("reporting metric " + m.toString());
+            reportExecutionMetric(m);
+        });
     }
 
     @Override
@@ -111,7 +115,6 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
             for (NBComponent child : children) {
                 child.close();
             }
-            reportMetrics();
             teardown();
         } catch (Exception e) {
             logger.error(e);
@@ -121,13 +124,6 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
                 parent.detachChild(this);
             }
         }
-    }
-
-    private void reportMetrics() {
-        this.getComponentMetrics().forEach(m -> {
-            logger.debug("reporting metric " + m.toString());
-            reportExecutionMetric(m);
-        });
     }
 
     public void reportExecutionMetric(NBMetric m) {

--- a/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBBaseComponent.java
@@ -35,7 +35,7 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
     protected final NBComponent parent;
     protected final NBLabels labels;
     private final List<NBComponent> children = new ArrayList<>();
-    private NBMetricsBuffer metricsBuffer = new NBMetricsBuffer();
+    protected NBMetricsBuffer metricsBuffer = new NBMetricsBuffer();
     protected boolean bufferOrphanedMetrics = false;
 
     public NBBaseComponent(NBComponent parentComponent) {

--- a/nb-api/src/main/java/io/nosqlbench/components/NBComponent.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBComponent.java
@@ -16,6 +16,7 @@
 
 package io.nosqlbench.components;
 
+import io.nosqlbench.api.engine.metrics.instruments.NBMetric;
 import io.nosqlbench.api.labels.NBLabeledElement;
 import io.nosqlbench.api.labels.NBLabels;
 import io.nosqlbench.components.decorators.NBProviderSearch;
@@ -59,4 +60,6 @@ public interface NBComponent extends
 
     @Override
     void close() throws RuntimeException;
+
+    void reportExecutionMetric(NBMetric m);
 }

--- a/nb-api/src/main/java/io/nosqlbench/components/NBComponentSubScope.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBComponentSubScope.java
@@ -17,6 +17,7 @@
 package io.nosqlbench.components;
 
 import io.nosqlbench.api.config.standard.TestComponent;
+import io.nosqlbench.components.events.ComponentOutOfScope;
 
 public class NBComponentSubScope implements AutoCloseable {
 
@@ -29,6 +30,7 @@ public class NBComponentSubScope implements AutoCloseable {
     public void close() throws RuntimeException {
         for (NBComponent component : components) {
             component.beforeDetach();
+            component.onEvent(new ComponentOutOfScope(component));
             NBComponent parent = component.getParent();
             if (parent!=null) {
                 parent.detachChild(component);

--- a/nb-api/src/main/java/io/nosqlbench/components/NBCreators.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBCreators.java
@@ -31,6 +31,7 @@ import io.nosqlbench.api.engine.metrics.reporters.PromPushReporterComponent;
 import io.nosqlbench.api.histo.HdrHistoLog;
 import io.nosqlbench.api.histo.HistoStats;
 import io.nosqlbench.api.http.HttpPlugin;
+import io.nosqlbench.api.labels.MapLabels;
 import io.nosqlbench.api.optimizers.BobyqaOptimizerInstance;
 import io.nosqlbench.api.files.FileAccess;
 import io.nosqlbench.api.labels.NBLabels;
@@ -315,7 +316,7 @@ public class NBCreators {
     public static class ConsoleReporterBuilder {
         private final NBComponent component;
         private final PrintStream output;
-        private NBLabels labels = null;
+        private NBLabels labels = new MapLabels(Map.of());
         private long interval = 1000;
         private boolean oneLastTime = false;
         private Set<MetricAttribute> disabledMetricAttributes = Set.of();

--- a/nb-api/src/main/java/io/nosqlbench/components/NBMetricsBuffer.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBMetricsBuffer.java
@@ -1,0 +1,38 @@
+package io.nosqlbench.components;
+
+import io.nosqlbench.api.engine.metrics.instruments.NBMetric;
+import io.nosqlbench.api.engine.metrics.reporters.ConsoleReporter;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NBMetricsBuffer {
+    private List<NBMetric> summaryMetrics = new ArrayList<>();
+    private PrintStream out = System.out;
+
+    public void setPrintStream(PrintStream out) {
+        this.out = out;
+    }
+
+    public List<NBMetric> getSummaryMetrics() {
+        return summaryMetrics;
+    }
+
+    public void setSummaryMetrics(List<NBMetric> summaryMetrics) {
+        this.summaryMetrics = summaryMetrics;
+    }
+
+    public void addSummaryMetric(NBMetric metric) {
+        this.summaryMetrics.add(metric);
+    }
+
+    public void clearSummaryMetrics() {
+        this.summaryMetrics.clear();
+    }
+
+    public void printMetricSummary(NBComponent caller) {
+        ConsoleReporter summaryReporter = new NBCreators.ConsoleReporterBuilder(caller, this.out).build();
+        summaryReporter.reportOnce(summaryMetrics);
+    }
+}

--- a/nb-api/src/main/java/io/nosqlbench/components/NBMetricsBuffer.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/NBMetricsBuffer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022-2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.nosqlbench.components;
 
 import io.nosqlbench.api.engine.metrics.instruments.NBMetric;

--- a/nb-api/src/main/java/io/nosqlbench/components/events/ComponentOutOfScope.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/events/ComponentOutOfScope.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022-2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.nosqlbench.components.events;
 
 import io.nosqlbench.components.DownEvent;

--- a/nb-api/src/main/java/io/nosqlbench/components/events/ComponentOutOfScope.java
+++ b/nb-api/src/main/java/io/nosqlbench/components/events/ComponentOutOfScope.java
@@ -1,0 +1,12 @@
+package io.nosqlbench.components.events;
+
+import io.nosqlbench.components.DownEvent;
+import io.nosqlbench.components.NBComponent;
+
+public class ComponentOutOfScope implements NBEvent {
+    private final NBComponent component;
+
+    public ComponentOutOfScope(NBComponent component) {
+        this.component = component;
+    }
+}


### PR DESCRIPTION
buffer metrics that go out of scope before end of test at the session level and print to screen at end of session.

See https://github.com/nosqlbench/nosqlbench/issues/1611