### PR TITLE
Mwolters/reset cmd

### DIFF
--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023-2024 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.nosqlbench.scenarios.simframe.optimizers;
+
+import io.nosqlbench.engine.api.activityapi.core.Activity;
+import io.nosqlbench.engine.api.activityapi.simrate.CycleRateSpec;
+import io.nosqlbench.engine.api.activityapi.simrate.SimRateSpec;
+import io.nosqlbench.engine.core.lifecycle.scenario.container.ContainerActivitiesController;
+import io.nosqlbench.engine.core.lifecycle.scenario.container.NBBufferedContainer;
+import io.nosqlbench.engine.core.lifecycle.scenario.container.NBCommandParams;
+import io.nosqlbench.engine.core.lifecycle.scenario.execution.NBBaseCommand;
+import io.nosqlbench.nb.annotations.Service;
+import io.nosqlbench.nb.api.components.events.ParamChange;
+import io.nosqlbench.nb.api.engine.activityimpl.ActivityDef;
+import io.nosqlbench.nb.api.engine.activityimpl.ParameterMap;
+import io.nosqlbench.nb.api.errors.BasicError;
+import io.nosqlbench.scenarios.simframe.SimFrameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.util.Map;
+import java.util.Optional;
+
+@Service(value = NBBaseCommand.class,selector = "reset")
+public class CMD_reset extends NBBaseCommand {
+    public final static Logger logger = LogManager.getLogger("reset");
+
+    public CMD_reset(NBBufferedContainer parentComponent, String scenarioName, String context) {
+        super(parentComponent, scenarioName, context);
+    }
+
+    @Override
+    public Object invoke(NBCommandParams params, PrintWriter stdout, PrintWriter stderr, Reader stdin, ContainerActivitiesController controller) {
+        Optional<Activity> optionalActivity = Optional.ofNullable(params.get("activity")).flatMap(controller::getActivity);
+        if (params.get("activity")!=null && optionalActivity.isEmpty()) {
+            throw new RuntimeException("you specified activity '" + params.get("activity") + "' but it was not found.");
+        }
+        Activity flywheel = optionalActivity.or(controller::getSoloActivity)
+            .orElseThrow(() -> new RuntimeException("You didn't provide the name of an activity to attach to, nor was there a solo activity available in this context"));
+
+        //if (flywheel.getActivityDef().getParams().getOptionalString("cycles").isEmpty()) {
+        //params   .getOptionalLong("rate")
+        flywheel.onEvent(new ParamChange<>(new CycleRateSpec(100.0d, 1.1d, SimRateSpec.Verb.restart)));
+        flywheel.getActivityDef().setEndCycle(Long.parseLong((String) flywheel.getActivityDef().getParams().get("cycles")));
+
+        SimFrameUtils.awaitActivity(flywheel);
+        NBCommandParams newParams = NBCommandParams.of(flywheel.getActivityDef().getParams().getStringStringMap());
+//        controller.run(newParams);
+        return null;
+    }
+}

--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
@@ -96,6 +96,7 @@ public class CMD_reset extends NBBaseCommand {
         flywheel.onEvent(ParamChange.of(new SetThreads((int)Math.round(Double.parseDouble(threadStr)))));
 
         SimFrameUtils.awaitActivity(flywheel);
+        flywheel.getMotorDispenserDelegate().getMotor(flywheel.getActivityDef(), 0).run();
 
         return null;
     }

--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
@@ -26,6 +26,7 @@ import io.nosqlbench.engine.core.lifecycle.scenario.container.NBCommandParams;
 import io.nosqlbench.engine.core.lifecycle.scenario.execution.NBBaseCommand;
 import io.nosqlbench.nb.annotations.Service;
 import io.nosqlbench.nb.api.components.events.ParamChange;
+import io.nosqlbench.nb.api.components.events.SetThreads;
 import io.nosqlbench.nb.api.engine.activityimpl.ActivityDef;
 import io.nosqlbench.nb.api.engine.activityimpl.ParameterMap;
 import io.nosqlbench.nb.api.errors.BasicError;
@@ -41,6 +42,8 @@ import java.util.Optional;
 @Service(value = NBBaseCommand.class,selector = "reset")
 public class CMD_reset extends NBBaseCommand {
     public final static Logger logger = LogManager.getLogger("reset");
+    public static final String DEFAULT_RATE = "100";
+    public static final String DEFAULT_THREADS = "10";
 
     public CMD_reset(NBBufferedContainer parentComponent, String scenarioName, String context) {
         super(parentComponent, scenarioName, context);
@@ -55,14 +58,34 @@ public class CMD_reset extends NBBaseCommand {
         Activity flywheel = optionalActivity.or(controller::getSoloActivity)
             .orElseThrow(() -> new RuntimeException("You didn't provide the name of an activity to attach to, nor was there a solo activity available in this context"));
 
-        //if (flywheel.getActivityDef().getParams().getOptionalString("cycles").isEmpty()) {
-        //params   .getOptionalLong("rate")
-        flywheel.onEvent(new ParamChange<>(new CycleRateSpec(100.0d, 1.1d, SimRateSpec.Verb.restart)));
-        flywheel.getActivityDef().setEndCycle(Long.parseLong((String) flywheel.getActivityDef().getParams().get("cycles")));
+        /*
+         Set the CycleRateSpec. This should be found in params.get("rate") if the value from a previous step is specified.
+         If not, the original might be found in the activity definition. If not, default to 100.
+         */
+        String rateStr = params.hasMember("rate") ? params.get("rate") :
+            flywheel.getActivityDef().getParams().getOptionalString("rate").orElse(DEFAULT_RATE);
+        logger.debug("Resetting rate to " + rateStr + " cycles per second");
+        flywheel.onEvent(new ParamChange<>(new CycleRateSpec(Double.parseDouble(rateStr), 1.1d, SimRateSpec.Verb.restart)));
+
+        // Get the original cycle count and re-apply it
+        long cycles = Long.parseLong((String) flywheel.getActivityDef().getParams().get("cycles"));
+        logger.debug("Resetting cycle count to " + cycles + " cycles");
+        flywheel.getActivityDef().setEndCycle(cycles);
+
+        /*
+         Set the thread count. First check for threads=${optimo.threads}. If that is not present check for
+         threads specification in the original activity. If that also is not present default to UNDEF.
+         Some odd behavior is noted with the optimo.threads value moving from params to the flywheel params
+         if threads were initially set, and that initial value being present in params. So if you're going to use
+         the reset command try not to explicitly set threads in the initial activity.
+         */
+        String threadStr = params.hasMember("threads") ? params.get("threads") :
+            flywheel.getActivityDef().getParams().getOptionalString("threads").orElse(DEFAULT_THREADS);
+        logger.debug("Resetting threads to " + threadStr);
+        flywheel.onEvent(ParamChange.of(new SetThreads((int)Math.round(Double.valueOf(threadStr)))));
 
         SimFrameUtils.awaitActivity(flywheel);
-        NBCommandParams newParams = NBCommandParams.of(flywheel.getActivityDef().getParams().getStringStringMap());
-//        controller.run(newParams);
+
         return null;
     }
 }

--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/CMD_reset.java
@@ -33,70 +33,69 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
 import java.io.Reader;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 
 @Service(value = NBBaseCommand.class,selector = "reset")
 public class CMD_reset extends NBBaseCommand {
     public final static Logger logger = LogManager.getLogger("reset");
-    public static final String DEFAULT_RATE = "100";
-    public static final String DEFAULT_THREADS = "10";
+    private static final HashSet<String> IGNORABLE = new HashSet<>(List.of("activity"));
 
     public CMD_reset(NBBufferedContainer parentComponent, String scenarioName, String context) {
         super(parentComponent, scenarioName, context);
     }
 
+    /**
+     * This command is used to restart the initial step activity in a scenario after optimization results have
+     * been determined by the previous steps. Any parameters that should be modified from the initially specified
+     * parameters for the activity should be specified on the command line, typically using bindings to reference
+     * the outputs of the previous steps, although this is not mandatory.
+     * @param params
+     * @param stdout
+     * @param stderr
+     * @param stdin
+     * @param controller
+     * @return null
+     */
     @Override
     public Object invoke(NBCommandParams params, PrintWriter stdout, PrintWriter stderr, Reader stdin, ContainerActivitiesController controller) {
         Optional<Activity> optionalActivity = Optional.ofNullable(params.get("activity")).flatMap(controller::getActivity);
         if (params.get("activity")!=null && optionalActivity.isEmpty()) {
             throw new RuntimeException("you specified activity '" + params.get("activity") + "' but it was not found.");
         }
-        Activity flywheel = optionalActivity.or(controller::getSoloActivity)
-            .orElseThrow(() -> new RuntimeException("You didn't provide the name of an activity to attach to, nor was there a solo activity available in this context"));
+        try (Activity flywheel = optionalActivity.or(controller::getSoloActivity)
+                .orElseThrow(() -> new RuntimeException("You didn't provide the name of an activity to attach to, nor was there a solo activity available in this context"))) {
 
-        /*
-         Set the CycleRateSpec. This should be found in params.get("rate") if the value from a previous step is specified.
-         If no value from a previous step is used, the original can be found in the flywheel activity definition.
-         If a value is passed in on the command line as opposed to specified in the yaml file it will override other values, so don't do this.
+            params.forEach((key, value) -> {
+                switch (key) {
+                    case "rate" -> {
+                        logger.debug("Resetting rate to " + value + " cycles per second");
+                        flywheel.onEvent(new ParamChange<>(new CycleRateSpec(Double.parseDouble(value), 1.1d, SimRateSpec.Verb.restart)));
+                    }
+                    case "threads" -> {
+                        logger.debug("Resetting threads to " + value + " threads");
+                        flywheel.onEvent(ParamChange.of(new SetThreads((int) Math.round(Double.parseDouble(value)))));
+                    }
+                    default -> {
+                        if (!IGNORABLE.contains(key)) {
+                            logger.debug("Resetting parameter: " + key + " to " + value);
+                            flywheel.getActivityDef().getParams().put(key, value);
+                        }
+                    }
+                }
+            });
 
-         cli rate|   yaml rate|  reset rate| params rate| flywheel params rate
-         null	 |   1	      |  50	       | 50	        | 1
-         null	 |   null	  |  50	       | 50	        | null
-         null	 |   1	      |  null	   | null	    | 1
-         1	     |   5	      |  50	       | 1	        | 1
-         1	     |   null	  |  50	       | 1	        | 1
-         */
-        String rateStr = params.hasMember("rate") ? params.get("rate") :
-            flywheel.getActivityDef().getParams().getOptionalString("rate").orElse(DEFAULT_RATE);
-        logger.debug("Resetting rate to " + rateStr + " cycles per second");
-        flywheel.onEvent(new ParamChange<>(new CycleRateSpec(Double.parseDouble(rateStr), 1.1d, SimRateSpec.Verb.restart)));
+            // Get the original cycle count and re-apply it
+            long cycles = Long.parseLong((String) flywheel.getActivityDef().getParams().get("cycles"));
+            logger.debug("Resetting cycle count to " + cycles + " cycles");
+            flywheel.getActivityDef().setEndCycle(cycles);
 
-        // Get the original cycle count and re-apply it
-        long cycles = Long.parseLong((String) flywheel.getActivityDef().getParams().get("cycles"));
-        logger.debug("Resetting cycle count to " + cycles + " cycles");
-        flywheel.getActivityDef().setEndCycle(cycles);
-
-        /*
-         Set the thread count. This should be found in params and the flywheel if the value from a previous step is specified.
-         If no value from a previous step is used, the original can be found in the flywheel activity definition.
-         If a value is passed in on the command line as opposed to specified in the yaml file it will be found in params
-         and the correct optimo thread count can be found in the flywheel, so in this case we go to the flywheel first
-
-         cli threads|   yaml threads|  reset threads| params threads| flywheel params threads
-         null	    |   1	        |  50	        | 50	        | 50
-         null	    |   null	    |  50	        | 50	        | 50
-         null	    |   1	        |  null	        | null	        | 1
-         1	        |   5	        |  50	        | 1	            | 50
-         1	        |   null	    |  50	        | 1	            | 50
-         */
-
-        String threadStr = flywheel.getActivityDef().getParams().getOptionalString("threads")
-                .orElse(params.hasMember("threads") ? params.get("threads") : DEFAULT_THREADS);
-        logger.debug("Resetting threads to " + threadStr);
-        flywheel.onEvent(ParamChange.of(new SetThreads((int)Math.round(Double.parseDouble(threadStr)))));
-
-        SimFrameUtils.awaitActivity(flywheel);
-        flywheel.getMotorDispenserDelegate().getMotor(flywheel.getActivityDef(), 0).run();
+            //TODO: This needs to be reworked, but simply calling controller.start on the flywheel results in 2
+            //      copies of the activity running simultaneously. This is a temporary workaround.
+            SimFrameUtils.awaitActivity(flywheel);
+            flywheel.getMotorDispenserDelegate().getMotor(flywheel.getActivityDef(), 0).run();
+        }
 
         return null;
     }

--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/INFO_reset.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/optimizers/INFO_reset.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023-2024 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.nosqlbench.scenarios.simframe.optimizers;
+
+import io.nosqlbench.engine.core.lifecycle.scenario.execution.NBCommandInfo;
+import io.nosqlbench.engine.core.lifecycle.scenario.execution.NBInvokableCommand;
+import io.nosqlbench.nb.annotations.Service;
+
+@Service(value = NBCommandInfo.class,selector = "reset")
+public class INFO_reset extends NBCommandInfo {
+    @Override
+    public Class<? extends NBInvokableCommand> getType() {
+        return CMD_reset.class;
+    }
+}


### PR DESCRIPTION
Reset command to add to optimization pipeline. Ex:

    test: >-
      start driver=cqld4 alias=search tags='block:test-numeric-sai,optype=select' labels='target:astra'
      cycles===TEMPLATE(testsize) errors=counter radius=TEMPLATE(radius) 

    findmax: optimize planner=findmax rate_step=10

    optimo: optimo startrate=${optimize.computed_rate} sample_time_ms=1000

    retest: reset activity=${start.activity} threads=${optimo.threads} rate=${optimo.rate} 
