### PR TITLE
Graal Dep downgrade to fix build errors

### DIFF
--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -361,7 +361,7 @@
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
-                <version>23.1.1</version>
+                <version>23.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.js</groupId>
@@ -372,7 +372,7 @@
             <dependency>
                 <groupId>org.graalvm.js</groupId>
                 <artifactId>js-scriptengine</artifactId>
-                <version>23.1.1</version>
+                <version>23.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.tools</groupId>
@@ -383,7 +383,7 @@
             <dependency>
                 <groupId>org.graalvm.tools</groupId>
                 <artifactId>chromeinspector</artifactId>
-                <version>23.0.1</version>
+                <version>23.0.3</version>
                 <scope>runtime</scope>
             </dependency>
 

--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -361,7 +361,7 @@
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
-                <version>23.1.2</version>
+                <version>23.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.js</groupId>
@@ -372,7 +372,7 @@
             <dependency>
                 <groupId>org.graalvm.js</groupId>
                 <artifactId>js-scriptengine</artifactId>
-                <version>23.1.2</version>
+                <version>23.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.tools</groupId>


### PR DESCRIPTION
Fix errors like below,

https://github.com/nosqlbench/nosqlbench/actions/runs/7892514765/job/21539155335#step:6:1852

```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.IllegalStateException: Polyglot version compatibility check failed.
The polyglot version '23.1.2' is not compatible to the used Truffle version '23.1.1'.
The Truffle or language version is older than the polyglot version in use.
The polygot and truffle version must always match.
Update the Truffle or language versions to '23.1.2' to resolve this.
To disable this version check the '-Dpolyglotimpl.DisableVersionChecks=true' system property can be used.
It is not recommended to disable version checks.
```

