### PR TITLE
Implement thread-local scope for rate limiters and improve spec format

### DIFF
--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/components/core/NBBaseComponent.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/components/core/NBBaseComponent.java
@@ -74,7 +74,7 @@ public class NBBaseComponent extends NBBaseComponentMetrics implements NBCompone
     }
 
     @Override
-    public NBComponent attachChild(NBComponent... children) {
+    public synchronized NBComponent attachChild(NBComponent... children) {
 
         for (NBComponent child : children) {
             logger.debug(() -> "attaching " + child.description() + " to parent " + this.description());

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/core/Activity.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/core/Activity.java
@@ -106,22 +106,6 @@ public interface Activity extends Comparable<Activity>, ActivityDefObserver, Pro
      */
     RateLimiter getCycleLimiter();
 
-    /**
-     * Set the cycle rate limiter for this activity. This method should only
-     * be used non-concurrently. Otherwise, the supplier version
-     * {@link #getCycleRateLimiter(Supplier)} should be used.
-     * @param rateLimiter The cycle {@link RateLimiter} for this activity
-     */
-    void setCycleLimiter(RateLimiter rateLimiter);
-
-    /**
-     * Get or create the cycle rate limiter in a safe way. Implementations
-     * should ensure that this method is synchronized or that each requester
-     * gets the same cycle rate limiter for the activity.
-     * @param supplier A {@link RateLimiter} {@link Supplier}
-     * @return An extant or newly created cycle {@link RateLimiter}
-     */
-    RateLimiter getCycleRateLimiter(Supplier<? extends RateLimiter> supplier);
 
     /**
      * Get the current stride rate limiter for this activity.
@@ -130,23 +114,6 @@ public interface Activity extends Comparable<Activity>, ActivityDefObserver, Pro
      * @return The stride {@link RateLimiter}
      */
     RateLimiter getStrideLimiter();
-
-    /**
-     * Set the stride rate limiter for this activity. This method should only
-     * be used non-concurrently. Otherwise, the supplier version
-     * {@link #getStrideRateLimiter(Supplier)}} should be used.
-     * @param rateLimiter The stride {@link RateLimiter} for this activity.
-     */
-    void setStrideLimiter(RateLimiter rateLimiter);
-
-    /**
-     * Get or create the stride {@link RateLimiter} in a concurrent-safe
-     * way. Implementations should ensure that this method is synchronized or
-     * that each requester gets the same stride rate limiter for the activity.
-     * @param supplier A {@link RateLimiter} {@link Supplier}
-     * @return An extant or newly created stride {@link RateLimiter}
-     */
-    RateLimiter getStrideRateLimiter(Supplier<? extends RateLimiter> supplier);
 
     /**
      * Get or create the instrumentation needed for this activity. This provides

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/simrate/SimRate.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/simrate/SimRate.java
@@ -79,7 +79,11 @@ public class SimRate extends NBBaseComponent implements RateLimiter, Thread.Unca
     private long startTime;
 
     public SimRate(NBComponent parent, SimRateSpec spec) {
-        super(parent, NBLabels.forKV().and("rateType",
+        this(parent, spec, NBLabels.forKV());
+    }
+
+    public SimRate(NBComponent parent, SimRateSpec spec, NBLabels extraLabels) {
+        super(parent, extraLabels.and("rateType",
             (spec instanceof CycleRateSpec? "cycle" : "stride")));
         this.spec = spec;
         initMetrics();

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/simrate/ThreadLocalRateLimiters.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityapi/simrate/ThreadLocalRateLimiters.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022-2023 nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nosqlbench.engine.api.activityapi.simrate;
+
+import io.nosqlbench.nb.api.components.core.NBComponent;
+import io.nosqlbench.nb.api.labels.NBLabels;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.function.Supplier;
+
+public class ThreadLocalRateLimiters {
+
+    private static final Logger logger = LogManager.getLogger(ThreadLocalRateLimiters.class);
+
+    public static synchronized ThreadLocal<RateLimiter> createOrUpdate(
+        final NBComponent parent,
+        final ThreadLocal<RateLimiter> extantSource,
+        final SimRateSpec spec
+    ) {
+        if (extantSource != null) {
+            RateLimiter rl = extantSource.get();
+            rl.applyRateSpec(spec);
+            return extantSource;
+        } else {
+            Supplier<RateLimiter> rls;
+            rls = switch (spec.getScope()) {
+                case activity -> {
+                    SimRate rl = new SimRate(parent, spec);
+                    yield () -> rl;
+                }
+                case thread -> () -> new SimRate(
+                    parent,
+                    spec,
+                    NBLabels.forKV("thread", Thread.currentThread().getName())
+                );
+            };
+            return ThreadLocal.withInitial(rls);
+        }
+    }
+
+}

--- a/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/SimRateSpecTest.java
+++ b/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/SimRateSpecTest.java
@@ -46,4 +46,19 @@ public class SimRateSpecTest {
         SimRateSpec c = new SimRateSpec("12345,1.1");
         assertThat(c.verb).isEqualTo(SimRateSpec.Verb.start);
     }
+
+    @Test
+    public void testScopeSelection() {
+        SimRateSpec asd = new SimRateSpec("12345,1.4");
+        assertThat(asd.getScope()).isEqualTo(SimRateSpec.Scope.activity);
+        SimRateSpec ts = new SimRateSpec("12345,1.4,start,thread");
+        assertThat(ts.getScope()).isEqualTo(SimRateSpec.Scope.thread);
+        SimRateSpec as = new SimRateSpec("12345,1.4,start,activity");
+        assertThat(as.getScope()).isEqualTo(SimRateSpec.Scope.activity);
+        SimRateSpec asa = new SimRateSpec("12345,1.4,activity");
+        assertThat(asa.getScope()).isEqualTo(SimRateSpec.Scope.activity);
+        SimRateSpec ast = new SimRateSpec("12345,1.4,thread");
+        assertThat(ast.getScope()).isEqualTo(SimRateSpec.Scope.thread);
+
+    }
 }

--- a/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/SimRateSpecTest.java
+++ b/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/activityapi/ratelimits/SimRateSpecTest.java
@@ -48,17 +48,31 @@ public class SimRateSpecTest {
     }
 
     @Test
-    public void testScopeSelection() {
-        SimRateSpec asd = new SimRateSpec("12345,1.4");
-        assertThat(asd.getScope()).isEqualTo(SimRateSpec.Scope.activity);
-        SimRateSpec ts = new SimRateSpec("12345,1.4,start,thread");
-        assertThat(ts.getScope()).isEqualTo(SimRateSpec.Scope.thread);
-        SimRateSpec as = new SimRateSpec("12345,1.4,start,activity");
-        assertThat(as.getScope()).isEqualTo(SimRateSpec.Scope.activity);
-        SimRateSpec asa = new SimRateSpec("12345,1.4,activity");
-        assertThat(asa.getScope()).isEqualTo(SimRateSpec.Scope.activity);
-        SimRateSpec ast = new SimRateSpec("12345,1.4,thread");
-        assertThat(ast.getScope()).isEqualTo(SimRateSpec.Scope.thread);
+    public void testVariantFormats() {
+        assertThat(new SimRateSpec("12345"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.1d, SimRateSpec.Verb.start, SimRateSpec.Scope.activity
+                ));
+        assertThat(new SimRateSpec("12345,1.4"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.4d, SimRateSpec.Verb.start, SimRateSpec.Scope.activity
+                ));
+        assertThat(new SimRateSpec("12345,configure"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.1d, SimRateSpec.Verb.configure, SimRateSpec.Scope.activity
+                ));
+        assertThat(new SimRateSpec("12345,thread"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.1d, SimRateSpec.Verb.start, SimRateSpec.Scope.thread
+                ));
+        assertThat(new SimRateSpec("12345,1.4,thread"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.4d, SimRateSpec.Verb.start, SimRateSpec.Scope.thread
+                ));
+        assertThat(new SimRateSpec("12345,configure,activity"))
+                .isEqualTo(new SimRateSpec(
+                        12345.0d, 1.1d, SimRateSpec.Verb.configure, SimRateSpec.Scope.activity
+                ));
 
     }
 }


### PR DESCRIPTION
This PR implements an optional scope specifier on rate limiters which can control whether a rate limiter is applied across all combined operations of an activity, or alternately, instanced per-thread using ThreadLocal.

Updates to thread-scoped rate limiters are not supported yet, but this can be added by adding event propagation for those configuration events into the component tree's event routing. 

Each rate limiter is a full implementation as before, which includes a fully-separate instance of a semaphore and a tasking thread to keep filling the token bucket. As such, many such per-thread rate limiters will consume incrementally more resources, so running thousands of them is not advised.

The session logs below will explain the behavior and formats that need to be documented.

## 10 threads running at 1 op/s each
(_each_ because of scope `thread`)

```
# nb5 run driver=diag cycles=100 rate=1,thread --progress=console:1s threads=10
DIAG0 (pending,current,complete)=(90,0,10) 10.00%
DIAG0 (pending,current,complete)=(80,0,20) 20.00%
DIAG0 (pending,current,complete)=(70,0,30) 30.00%
DIAG0 (pending,current,complete)=(60,0,40) 40.00%
DIAG0 (pending,current,complete)=(50,0,50) 50.00%
DIAG0 (pending,current,complete)=(40,0,60) 60.00%
DIAG0 (pending,current,complete)=(30,0,70) 70.00%
DIAG0 (pending,current,complete)=(20,0,80) 80.00%
DIAG0 (pending,current,complete)=(10,0,90) 90.00%
DIAG0 (pending,current,complete)=(0,0,100) 100.00% (last report)
```

## 1 thread running at 10 ops/s
```
# nb5 run driver=diag cycles=100 rate=10,thread --progress=console:1s threads=1
DIAG0 (pending,current,complete)=(97,0,3) 3.00%
DIAG0 (pending,current,complete)=(87,0,13) 13.00%
DIAG0 (pending,current,complete)=(77,0,23) 23.00%
DIAG0 (pending,current,complete)=(67,0,33) 33.00%
DIAG0 (pending,current,complete)=(57,0,43) 43.00%
DIAG0 (pending,current,complete)=(47,0,53) 53.00%
DIAG0 (pending,current,complete)=(37,0,63) 63.00%
DIAG0 (pending,current,complete)=(27,0,73) 73.00%
DIAG0 (pending,current,complete)=(17,0,83) 83.00%
DIAG0 (pending,current,complete)=(7,0,93) 93.00%
DIAG0 (pending,current,complete)=(0,0,100) 100.00% (last report)
```

## 5 threads running at 5 ops/s each
(_each_ because of scope `thread`)

```
# nb5 run driver=diag cycles=100 rate=5,thread --progress=console:1s threads=5
DIAG0 (pending,current,complete)=(90,0,10) 10.00%
DIAG0 (pending,current,complete)=(65,0,35) 35.00%
DIAG0 (pending,current,complete)=(40,0,60) 60.00%
DIAG0 (pending,current,complete)=(15,0,85) 85.00%
DIAG0 (pending,current,complete)=(0,0,100) 100.00% (last report)
```

## 5 threads running at 5 ops/s aggregate (default behavior)
(_aggregate_ because of scope `activity`)

```
nb5 run driver=diag cycles=100 rate=5,activity --progress=console:1s threads=5
DIAG0 (pending,current,complete)=(97,0,3) 3.00%
DIAG0 (pending,current,complete)=(92,0,8) 8.00%
DIAG0 (pending,current,complete)=(87,0,13) 13.00%
DIAG0 (pending,current,complete)=(82,0,18) 18.00%
DIAG0 (pending,current,complete)=(77,0,23) 23.00%
DIAG0 (pending,current,complete)=(72,0,28) 28.00%
DIAG0 (pending,current,complete)=(67,0,33) 33.00%
DIAG0 (pending,current,complete)=(62,0,38) 38.00%
DIAG0 (pending,current,complete)=(57,0,43) 43.00%
DIAG0 (pending,current,complete)=(52,0,48) 48.00%
DIAG0 (pending,current,complete)=(47,0,53) 53.00%
DIAG0 (pending,current,complete)=(42,0,58) 58.00%
DIAG0 (pending,current,complete)=(37,0,63) 63.00%
DIAG0 (pending,current,complete)=(32,0,68) 68.00%
DIAG0 (pending,current,complete)=(27,0,73) 73.00%
DIAG0 (pending,current,complete)=(22,0,78) 78.00%
DIAG0 (pending,current,complete)=(17,0,83) 83.00%
DIAG0 (pending,current,complete)=(12,0,88) 88.00%
DIAG0 (pending,current,complete)=(7,0,93) 93.00%
DIAG0 (pending,current,complete)=(2,0,98) 98.00%
DIAG0 (pending,current,complete)=(0,0,100) 100.00% (last report)
```

## error message for incorrect rate spec
```
# nb5 run driver=diag cycles=100 rate=5,wrong --progress=console:1s threads=5
    3051 ERROR [main] NBINVOKE     error   [CMD_run {container="default", REDACTED REDACTED}: io.nosqlbench.nb.api.errors.BasicError: Spec format '5,wrong' was not recognized for CycleRateSpec.
Use the format <ops/s>[,<burst ratio][,<verb>][,<scope>]
Examples:
 100 (100 ops per second)
 100,1.1 (with a burst ratio of 10% over)
 100,start (start the rate limiter automatically)
 100,thread (scope the rate limiter to each thread in an activity)
 100,1.1,start,thread (all of the above)
Defaults: burst_ratio=1.1 verb=start scope=activity
```
