### PR TITLE
Switch to Apache Cassandra Java Driver 4.18.1

### DIFF
--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -181,9 +181,19 @@
                 <version>1.4.1</version>
             </dependency>
             <dependency>
-                <groupId>com.datastax.oss</groupId>
+                <groupId>org.apache.cassandra</groupId>
+                <artifactId>java-driver-core</artifactId>
+                <version>4.18.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>java-driver-query-builder</artifactId>
-                <version>4.17.0</version>
+                <version>4.18.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cassandra</groupId>
+                <artifactId>java-driver-mapper-runtime</artifactId>
+                <version>4.18.1</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -374,6 +384,12 @@
                 <groupId>org.graalvm.js</groupId>
                 <artifactId>js-scriptengine</artifactId>
                 <version>23.1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.stephenc.jcip</groupId>
+                <artifactId>jcip-annotations</artifactId>
+                <scope>provided</scope>
+                <version>1.0-1</version>
             </dependency>
 
         </dependencies>

--- a/nb-adapters/adapter-cqld4/pom.xml
+++ b/nb-adapters/adapter-cqld4/pom.xml
@@ -57,15 +57,15 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.oss</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>4.17.0</version>
+            <version>4.18.1</version>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.oss</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>java-driver-query-builder</artifactId>
-            <version>4.17.0</version>
+            <version>4.18.1</version>
         </dependency>
 
         <dependency>
@@ -104,6 +104,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.17.0</version>
+        </dependency>
+        <!-- See https://issues.apache.org/jira/browse/CASSANDRA-18969 for more details -->
+        <dependency>
+            <groupId>com.github.stephenc.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <scope>provided</scope>
+            <version>1.0-1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Switch to [Apache Cassandra Java Driver `4.18.1`](https://github.com/apache/cassandra-java-driver/releases/tag/4.18.1) as [**DataStax** has already *donated* the driver to ASF on Nov 07, 2023 timeframe](https://stackoverflow.com/questions/77714194/cassandra-datastax-ipv6-connection/77714321#77714321).