### PR TITLE
fix for findmax early exit bug

### DIFF
--- a/nbr/src/main/java/io/nosqlbench/scenarios/simframe/SimFrameUtils.java
+++ b/nbr/src/main/java/io/nosqlbench/scenarios/simframe/SimFrameUtils.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.LockSupport;
 
 public class SimFrameUtils {
+    public static final String SIM_CYCLES = "sim_cycles";
 
     public static void awaitActivity(Activity flywheel) {
         // await flywheel actually spinning, or timeout with error
@@ -54,6 +55,8 @@ public class SimFrameUtils {
         // Start the flywheel at an "idle" speed, even if the user hasn't set it
         flywheel.onEvent(new ParamChange<>(new CycleRateSpec(100.0d, 1.1d, SimRateSpec.Verb.restart)));
         flywheel.getActivityDef().setEndCycle(Long.MAX_VALUE);
+        flywheel.getActivityDef().getParams().set(SIM_CYCLES, Long.MAX_VALUE);
+
         return flywheel;
     }
 }


### PR DESCRIPTION
When a task is initially put into state RUNNING it is configured to have a set number of cycles, after which it should be taken out of state RUNNING. Findmax and Optimo modify the task and reset the number of cycles to Long.MAX_VALUE to provide sufficient time for the optimization to run, however in fact this change is not respected by the CoreMotor which is taking the task out of state RUNNING when it hits the initially set number of cycles, rather than the modified one. This is happening because the CoreMotor variable input, an instance of AtomicInput, has max=the original value rather than max=reset value. The AtomicInput max value is set or reset through the onActivityDefUpdate method of the ActivityDefObserver interface, which is called when any value in the ActivityDef paramter map is modified. Changing the end cycle is not having the desired effect because it doesn't actually change anything in the parameter map, it sets the CycleSpec of the ActivityDef instead. This is resolved in this fix by simply updating the ActivityDef parameter map with a new contrived parameter ("sim_cycles") which achieves the desired affect of calling the registed ActivityDefObservers.

(This bug never affected Optimo because Optimo also varies the number of threads, which *does* update the parameter map whenever changed).