### PR TITLE
Cqlgen: Add conf 'disable_if_not_exists' to disable/enable 'if not exists' for DDL statements

### DIFF
--- a/nb-adapters/adapter-cqld4/src/main/resources/cqlgen/cqlgen.conf
+++ b/nb-adapters/adapter-cqld4/src/main/resources/cqlgen/cqlgen.conf
@@ -145,6 +145,6 @@ blockplan:
   # not needed when tags=block:'main.*'
   # main: insert, select, scan-10, update
 
-# Configuration option for removing 'IF NOT EXISTS' in all generated DDL statements
-disable_if_not_exists: false
+# Configuration option for adding 'IF NOT EXISTS' or 'IF EXISTS' in all generated DDL statements
+enable_if_exists: true
 

--- a/nb-adapters/adapter-cqld4/src/main/resources/cqlgen/cqlgen.conf
+++ b/nb-adapters/adapter-cqld4/src/main/resources/cqlgen/cqlgen.conf
@@ -145,6 +145,6 @@ blockplan:
   # not needed when tags=block:'main.*'
   # main: insert, select, scan-10, update
 
-
-
+# Configuration option for removing 'IF NOT EXISTS' in all generated DDL statements
+disable_if_not_exists: false
 


### PR DESCRIPTION
Added default `IF NOT EXISTS` in these generated statements:
* create keypace
* create table
* create type

which can be disabled by setting `disable_if_not_exists: true` in cqlgen.conf.

closes #817 
