### PR TITLE
Fixing a nullpointer error for delete_one api of dataapi driver adapter

### DIFF
--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
@@ -66,9 +66,8 @@ public class DataApiDeleteOneOpDispenser extends DataApiOpDispenser {
     }
 
     private float[] getVectorFromOp(ParsedOp op, long l) {
-        Object rawVectorObject = op.get("vector", l);
-        if (rawVectorObject != null) {
-            return getVectorValues(rawVectorObject);
+        if (op.isDefined("vector")) {
+            return getVectorValues(op.get("vector", l));
         }
         return null;
     }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
@@ -66,7 +66,11 @@ public class DataApiDeleteOneOpDispenser extends DataApiOpDispenser {
     }
 
     private float[] getVectorFromOp(ParsedOp op, long l) {
-        return getVectorValues(op.get("vector", l));
+        Object rawVectorObject = op.get("vector", l);
+        if (rawVectorObject != null) {
+            return getVectorValues(rawVectorObject);
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Description
- When using `delete_one` api of the dataapi driver adapter with a filter for one string field without a vector filter, a nullpointer error was being thrown
- Added a check to fix it!!

**Ref logs:**
```
    6431 ERROR [/Users/sahan/Desktop/text/Tasks/Vector_Certification/image_retrieval_dapi.yaml:003] CoreMotor    Error in core motor loop:java.lang.RuntimeException: while binding request in cycle 21 for op template named 'delete_op': Cannot invoke "Object.getClass()" because "rawVectorValues" is null
java.lang.RuntimeException: while binding request in cycle 21 for op template named 'delete_op': Cannot invoke "Object.getClass()" because "rawVectorValues" is null
	at io.nosqlbench.engine.api.activityimpl.uniform.actions.StandardAction.runCycle(StandardAction.java:84)
	at io.nosqlbench.engine.api.activityimpl.motor.CoreMotor.run(CoreMotor.java:271)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "rawVectorValues" is null
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiOpDispenser.getVectorValues(DataApiOpDispenser.java:149)
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiDeleteOneOpDispenser.getVectorFromOp(DataApiDeleteOneOpDispenser.java:69)
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiDeleteOneOpDispenser.getDeleteOneOptions(DataApiDeleteOneOpDispenser.java:59)
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiDeleteOneOpDispenser.lambda$createOpFunction$0(DataApiDeleteOneOpDispenser.java:45)
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiDeleteOneOpDispenser.getOp(DataApiDeleteOneOpDispenser.java:74)
	at io.nosqlbench.adapter.dataapi.opdispensers.DataApiDeleteOneOpDispenser.getOp(DataApiDeleteOneOpDispenser.java:32)
	at io.nosqlbench.engine.api.activityimpl.uniform.actions.StandardAction.runCycle(StandardAction.java:81)
	... 4 more
```