### PR TITLE
MongoDB: Upgrade driver version and adapt to server 8.0.x

### DIFF
--- a/nb-adapters/adapter-mongodb/pom.xml
+++ b/nb-adapters/adapter-mongodb/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.11.1</version>
+            <version>5.2.0</version>
         </dependency>
     </dependencies>
 

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoSpace.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 nosqlbench
+ * Copyright (c) 2022-2024 nosqlbench
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import com.mongodb.ServerApi;
 import com.mongodb.ServerApiVersion;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-import io.nosqlbench.nb.api.components.core.NBNamedElement;
 import com.mongodb.client.MongoDatabase;
+import io.nosqlbench.nb.api.components.core.NBNamedElement;
 import io.nosqlbench.nb.api.config.standard.ConfigModel;
 import io.nosqlbench.nb.api.config.standard.NBConfigModel;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
@@ -84,11 +84,11 @@ public class MongoSpace implements NBNamedElement, AutoCloseable {
                 MongoClientSettings.getDefaultCodecRegistry()
         );
 
-        // https://www.mongodb.com/docs/v7.0/reference/stable-api
+        // https://www.mongodb.com/docs/manual/reference/stable-api
         ServerApi serverApi = ServerApi.builder()
             .version(ServerApiVersion.V1)
             .deprecationErrors(false)
-            .strict(false)//Needed because createSearchIndexes is not in stable API
+            .strict(false) // Needed because createSearchIndexes is not in stable API (yet)
             .build();
 
         MongoClientSettings settings = MongoClientSettings.builder()

--- a/nb-adapters/adapter-mongodb/src/main/resources/activities/baselinesv2/mongodb_vector_search.yaml
+++ b/nb-adapters/adapter-mongodb/src/main/resources/activities/baselinesv2/mongodb_vector_search.yaml
@@ -92,17 +92,16 @@ blocks:
           indexes: [
             {
               name: "kv_value_vector_search_idx",
+              type: "vectorSearch",
               definition: {
-                mappings: {
-                  dynamic: true,
-                  fields: {
-                    value: {
-                      type: "knnVector",
-                      dimensions: TEMPLATE(dimensions,1536),
-                      similarity: "TEMPLATE(similarity_function,cosine)"
-                    }
+                fields: [
+                  {
+                    type: "vector",
+                    path: "value",
+                    numDimensions: TEMPLATE(dimensions,1536),
+                    similarity: "TEMPLATE(similarity_function,cosine)"
                   }
-                }
+                ]
               }
             }
           ]
@@ -134,6 +133,7 @@ blocks:
             "pipeline": [
               {
                 "$vectorSearch": {
+                  "exact": false,
                   "index": "kv_value_vector_search_idx",
                   "path": "value",
                   "queryVector": {test_floatlist},
@@ -157,15 +157,18 @@ blocks:
           - io.nosqlbench.adapter.mongodb.MongoDbUtils
         verifier-init: |
           k=TEMPLATE(top_k,100)
-          relevancy=scriptingmetrics.newRelevancyMeasures(_parsed_op);
+          relevancy=new io.nosqlbench.nb.api.engine.metrics.wrappers.RelevancyMeasures(_parsed_op)
           relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.recall("recall",k));
           relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.precision("precision",k));
           relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.F1("F1",k));
           relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.reciprocal_rank("RR",k));
           relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.average_precision("AP",k));
+          windowed_relevancy = new io.nosqlbench.nb.api.engine.metrics.wrappers.WindowedRelevancyMeasures(_parsed_op,10);
+          windowed_relevancy.addFunction(io.nosqlbench.engine.extensions.computefunctions.RelevancyFunctions.recall("recall",k));
         verifier: |
           actual_indices=MongoDbUtils.getFieldFromResults("key",result);
           relevancy.accept({relevant_indices},actual_indices);
+          windowed_relevancy.accept({relevant_indices}, actual_indices);
           return true;
   main_write:
     params:


### PR DESCRIPTION
This upgrades the MongoDB driver adapter to [the most current & latest driver `5.2` version](https://www.mongodb.com/docs/drivers/java/sync/current/whats-new/) and also adapts to the newly released [`8.0` server version](https://www.mongodb.com/blog/post/mongodb-8-0-raising-the-bar).