### PR TITLE
Prompush Reporter: Adding Option to pass the apikeyfile

### DIFF
--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/components/core/NBCreators.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/components/core/NBCreators.java
@@ -158,8 +158,8 @@ public class NBCreators {
 //        AttachedMetricCsvReporter reporter = new AttachedMetricCsvReporter(base, extraLabels, Path.of(dirpath), seconds);
 //        return reporter;
 //    }
-    public PromPushReporterComponent pushReporter(String endpoint, long millis, NBLabels extraLabels) {
-        PromPushReporterComponent reporter = new PromPushReporterComponent(this.base, endpoint, millis, extraLabels);
+    public PromPushReporterComponent pushReporter(String endpoint, long millis, NBLabels extraLabels, String prompushApikeyfile) {
+        PromPushReporterComponent reporter = new PromPushReporterComponent(this.base, endpoint, millis, extraLabels, prompushApikeyfile);
         return reporter;
     }
 

--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/reporters/PromPushReporterComponent.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/reporters/PromPushReporterComponent.java
@@ -65,7 +65,6 @@ public class PromPushReporterComponent extends PeriodicTaskComponent {
             String[] parts = endpoint.split(":", 3);
             endpoint = "https://" + parts[2] + "/api/v1/import/prometheus/metrics/job/JOBNAME/instance/INSTANCE";
         } else if (endpoint.matches("victoria:[a-zA-Z0-9._-]+(:[0-9]+)?")) {
-            System.out.println("match3");
             String[] parts = endpoint.split(":", 2);
             endpoint = "https://" + parts[1] + "/api/v1/import/prometheus/metrics/job/JOBNAME/instance/INSTANCE";
         }

--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/reporters/PromPushReporterComponent.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/reporters/PromPushReporterComponent.java
@@ -50,7 +50,7 @@ public class PromPushReporterComponent extends PeriodicTaskComponent {
     private final URI uri;
     private String bearerToken;
 
-    public PromPushReporterComponent(NBComponent parent, String endpoint, long intervalMs, NBLabels nbLabels) {
+    public PromPushReporterComponent(NBComponent parent, String endpoint,long intervalMs, NBLabels nbLabels, String prompushApikeyfile) {
         super(parent, nbLabels.and("_type", "prom-push"), intervalMs,  "REPORT-PROMPUSH",FirstReport.OnInterval, LastReport.OnInterrupt);
         String jobname = getLabels().valueOfOptional("jobname").orElse("default");
         String instance = getLabels().valueOfOptional("instance").orElse("default");
@@ -58,11 +58,19 @@ public class PromPushReporterComponent extends PeriodicTaskComponent {
             logger.warn("It is highly recommended that you set a value for labels jobname and instance other than 'default'.");
         }
 
-        if (endpoint.matches("victoria:[a-zA-Z0-9._-]+:[0-9]+")) {
+        if (endpoint.matches("victoria:plain:[a-zA-Z0-9._-]+(:[0-9]+)?")) {
+            String[] parts = endpoint.split(":", 3);
+            endpoint = "http://" + parts[2] + "/api/v1/import/prometheus/metrics/job/JOBNAME/instance/INSTANCE";
+        } else if (endpoint.matches("victoria:tls:[a-zA-Z0-9._-]+(:[0-9]+)?")) {
+            String[] parts = endpoint.split(":", 3);
+            endpoint = "https://" + parts[2] + "/api/v1/import/prometheus/metrics/job/JOBNAME/instance/INSTANCE";
+        } else if (endpoint.matches("victoria:[a-zA-Z0-9._-]+(:[0-9]+)?")) {
+            System.out.println("match3");
             String[] parts = endpoint.split(":", 2);
             endpoint = "https://" + parts[1] + "/api/v1/import/prometheus/metrics/job/JOBNAME/instance/INSTANCE";
         }
         endpoint = endpoint.replace("JOBNAME", jobname).replace("INSTANCE", instance);
+        logger.trace("Prompush endpoint: {}", endpoint);
         if (!endpoint.contains(jobname)) {
             throw new BasicError("Mismatch between jobname in prompush URI and specified jobname label. You should use the short form for --report-prompush-to victoria:addr:port and set the jobname with --add-labels");
         }
@@ -70,10 +78,17 @@ public class PromPushReporterComponent extends PeriodicTaskComponent {
             throw new BasicError("Mismatch between instance in prompush URI and specified instance label. You should use the short form for --report-prompush-to victoria:addr:port and set the instance with --add-labels");
         }
         this.uri = URI.create(endpoint);
-        this.keyfilePath = NBEnvironment.INSTANCE
-            .interpolateWithTimestamp("$NBSTATEDIR/prompush/prompush_apikey", System.currentTimeMillis())
-            .map(Path::of)
-            .orElseThrow(() -> new RuntimeException("Unable to create path for apikey file: $NBSTATEDIR/prompush/prompush_apikey"));
+        if (prompushApikeyfile != null && !prompushApikeyfile.isEmpty()) {
+            this.keyfilePath = Path.of(prompushApikeyfile);
+            if (Files.notExists(this.keyfilePath)) {
+                throw new IllegalArgumentException(String.format("Given path '%s' for prompush-apikeyfile does not exist, please provide a valid path!!!", this.keyfilePath));
+            }
+        } else {
+            this.keyfilePath = NBEnvironment.INSTANCE
+                .interpolateWithTimestamp("$NBSTATEDIR/prompush/prompush_apikey", System.currentTimeMillis())
+                .map(Path::of)
+                .orElseThrow(() -> new RuntimeException("Unable to create path for apikey file: $NBSTATEDIR/prompush/prompush_apikey"));
+        }
         if (Files.isRegularFile(keyfilePath)) {
             try {
                 logger.debug(() -> "Reading Bearer Token from " + keyfilePath);
@@ -81,6 +96,8 @@ public class PromPushReporterComponent extends PeriodicTaskComponent {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        } else if (prompushApikeyfile != null && !prompushApikeyfile.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Unable to read the bearer token from the given file '%s'", this.keyfilePath));
         }
     }
 

--- a/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
+++ b/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLI.java
@@ -483,7 +483,7 @@ public class NBCLI implements Function<String[], Integer>, NBLabeledElement {
                     default:
                         throw new RuntimeException("Unable to parse '" + cfg + "', must be in <URI> or <URI>,ms form");
                 }
-                session.create().pushReporter(uri, intervalMs, NBLabels.forKV());
+                session.create().pushReporter(uri, intervalMs, NBLabels.forKV(), options.getPrompushApikeyfile());
             });
             for (final NBCLIOptions.LoggerConfigData histoLogger : options.getHistoLoggerConfigs()) {
                 session.create().histoLogger(sessionName, histoLogger.pattern, histoLogger.file, histoLogger.millis);

--- a/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
+++ b/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIOptions.java
@@ -118,6 +118,7 @@ public class NBCLIOptions {
     private static final String ENABLE_LOGGED_METRICS = "--enable-logged-metrics";
     private static final String DISABLE_LOGGED_METRICS = "--disable-logged-metrics";
     private static final String REPORT_PROMPUSH_TO = "--report-prompush-to";
+    private static final String PROMPUSH_API_KEYFILE = "--prompush-apikeyfile";
     private static final String GRAPHITE_LOG_LEVEL = "--graphite-log-level";
     private static final String REPORT_CSV_TO = "--report-csv-to";
     private static final String REPORT_SUMMARY_TO = "--report-summary-to";
@@ -164,6 +165,7 @@ public class NBCLIOptions {
     private boolean wantsBasicHelp;
     private String reportGraphiteTo;
     private String reportPromPushTo;
+    private String prompushApikeyfile;
     private String reportCsvTo;
     private String reportSqliteTo;
     private int reportInterval = 10;
@@ -286,6 +288,10 @@ public class NBCLIOptions {
 
     public boolean wantsToCatResource() {
         return this.wantsToCatResource != null && !this.wantsToCatResource.isEmpty();
+    }
+
+    public String getPrompushApikeyfile() {
+        return this.prompushApikeyfile;
     }
 
     public enum Mode {
@@ -413,6 +419,10 @@ public class NBCLIOptions {
                 case NBCLIOptions.REPORT_PROMPUSH_TO:
                     arglist.removeFirst();
                     this.reportPromPushTo = arglist.removeFirst();
+                    break;
+                case NBCLIOptions.PROMPUSH_API_KEYFILE:
+                    arglist.removeFirst();
+                    this.prompushApikeyfile = arglist.removeFirst();
                     break;
                 case NBCLIOptions.GRAPHITE_LOG_LEVEL:
                     arglist.removeFirst();


### PR DESCRIPTION
## Description
- Making the changes in the endpoint format as suggested in #1983 
- Adding a new NBCLI option to be to pass the prompush_apikeyfile location via CLI rather than just having it in a predefined location (`~/.nosqlbench/prompush/prompush_apikey`)