### PR TITLE
jshook/nosqlbench-2068-opspaces

### DIFF
--- a/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpDriverAdapter.java
+++ b/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpDriverAdapter.java
@@ -41,7 +41,7 @@ public class AmqpDriverAdapter extends BaseDriverAdapter<AmqpTimeTrackOp, AmqpSp
 
     @Override
     public OpMapper<AmqpTimeTrackOp, AmqpSpace> getOpMapper() {
-        return new AmqpOpMapper(this, getConfiguration(), getSpaceCache());
+        return new AmqpOpMapper(this, getConfiguration());
     }
 
     @Override

--- a/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpOpMapper.java
+++ b/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpOpMapper.java
@@ -37,12 +37,10 @@ public class AmqpOpMapper implements OpMapper<AmqpTimeTrackOp,AmqpSpace> {
     private final static Logger logger = LogManager.getLogger(AmqpOpMapper.class);
 
     private final NBConfiguration cfg;
-    private final ConcurrentSpaceCache<AmqpSpace> spaceCache;
-    private final DriverAdapter adapter;
+    private final AmqpDriverAdapter adapter;
 
-    public AmqpOpMapper(DriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<AmqpSpace> spaceCache) {
+    public AmqpOpMapper(AmqpDriverAdapter adapter, NBConfiguration cfg) {
         this.cfg = cfg;
-        this.spaceCache = spaceCache;
         this.adapter = adapter;
     }
 
@@ -50,7 +48,6 @@ public class AmqpOpMapper implements OpMapper<AmqpTimeTrackOp,AmqpSpace> {
         public OpDispenser<AmqpTimeTrackOp> apply(ParsedOp op, LongFunction spaceInitF) {
     //public OpDispenser<AmqpTimeTrackOp> apply(ParsedOp op, LongFunction<AmqpTimeTrackOp> spaceInitF) {
         int spaceName = op.getStaticConfigOr("space", 0);
-        AmqpSpace amqpSpace = spaceCache.get(spaceName);
 
         /*
          * If the user provides a body element, then they want to provide the JSON or
@@ -65,9 +62,9 @@ public class AmqpOpMapper implements OpMapper<AmqpTimeTrackOp,AmqpSpace> {
 
             return switch (opType.enumId) {
                 case AmqpMsgSender ->
-                    new AmqpMsgSendOpDispenser(adapter, op, amqpSpace);
+                    new AmqpMsgSendOpDispenser(adapter, op);
                 case AmqpMsgReceiver ->
-                    new AmqpMsgRecvOpDispenser(adapter, op, amqpSpace);
+                    new AmqpMsgRecvOpDispenser(adapter, op);
             };
         }
     }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4BaseOpDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4BaseOpDispenser.java
@@ -58,7 +58,7 @@ public abstract class Cqld4BaseOpDispenser<T extends Cqld4BaseOp<?>> extends Bas
     public Cqld4BaseOpDispenser(Cqld4DriverAdapter adapter,
                                 ParsedOp op) {
         super((DriverAdapter<? extends T, ? extends Cqld4Space>) adapter, op);
-        this.sessionF = l -> adapter.getSpaceCache().get(l).getSession();
+        this.sessionF = l -> adapter.getSpaceFunc(op).apply(l).getSession();
         this.maxpages = op.getStaticConfigOr("maxpages", 1);
         this.isRetryReplace = op.getStaticConfigOr("retryreplace", false);
         this.maxLwtRetries = op.getStaticConfigOr("maxlwtretries", 1);

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4PreparedStmtDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4PreparedStmtDispenser.java
@@ -76,7 +76,7 @@ public class Cqld4PreparedStmtDispenser extends Cqld4BaseOpDispenser<Cqld4CqlPre
                 (long l) -> (sessionF.apply(l)).prepare(preparedQueryString);
 
             LongFunction<? extends Cqld4Space> lookupSpaceF =
-                (long l) -> adapter.getSpaceCache().get(l);
+                (long l) -> adapter.getSpaceFunc(op).apply(l);
 
             int refKey = op.getRefKey();
             LongFunction<PreparedStatement> cachedStatementF =

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4BaseOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4BaseOpMapper.java
@@ -33,13 +33,9 @@ public abstract class Cqld4BaseOpMapper<T extends Cqld4BaseOp<?>> implements OpM
 
     protected final static Logger logger = LogManager.getLogger(Cqld4BaseOpMapper.class);
     protected final Cqld4DriverAdapter adapter;
-    protected final LongFunction<Cqld4Space> spaceFunc;
-    protected final LongFunction<CqlSession> sessionFunc;
 
     public Cqld4BaseOpMapper(Cqld4DriverAdapter adapter) {
         this.adapter = adapter;
-        spaceFunc = l -> adapter.getSpaceCache().get(l);
-        sessionFunc = l -> spaceFunc.apply(l).getSession();
     }
 
     @Override

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CoreOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CoreOpMapper.java
@@ -51,17 +51,17 @@ public class Cqld4CoreOpMapper extends Cqld4BaseOpMapper<Cqld4BaseOp<?>> {
      */
 
     @Override
-    public OpDispenser<Cqld4BaseOp<?>> apply(ParsedOp op, LongFunction<Cqld4Space> cqld4SpaceLongFunction) {
+    public OpDispenser<Cqld4BaseOp<?>> apply(ParsedOp op, LongFunction<Cqld4Space> spaceF) {
         CqlD4OpType opType = CqlD4OpType.prepared;
         TypeAndTarget<CqlD4OpType, String> target = op.getTypeAndTarget(CqlD4OpType.class, String.class, "type", "stmt");
         logger.info(() -> "Using " + target.enumId + " statement form for '" + op.getName() + "'");
 
         return (OpDispenser<Cqld4BaseOp<?>>) switch (target.enumId) {
-            case raw, simple, prepared, batch -> new Cqld4CqlOpMapper(adapter).apply(op, spaceFunc);
-            case gremlin -> new Cqld4GremlinOpMapper(adapter, target.targetFunction).apply(op, spaceFunc);
-            case fluent -> new Cqld4FluentGraphOpMapper(adapter, target).apply(op, spaceFunc);
+            case raw, simple, prepared, batch -> new Cqld4CqlOpMapper(adapter).apply(op, spaceF);
+            case gremlin -> new Cqld4GremlinOpMapper(adapter, target.targetFunction).apply(op, spaceF);
+            case fluent -> new Cqld4FluentGraphOpMapper(adapter, target).apply(op, spaceF);
             case rainbow ->
-                new CqlD4RainbowTableMapper(adapter, sessionFunc, target.targetFunction).apply(op, spaceFunc);
+                new CqlD4RainbowTableMapper(adapter, spaceF, target.targetFunction).apply(op, spaceF);
             default -> throw new OpConfigError("Unsupported op type " + opType);
 //            case sst -> new Cqld4SsTableMapper(adapter, sessionFunc, target.targetFunction).apply(op);
         };

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlOpMapper.java
@@ -46,13 +46,13 @@ public class Cqld4CqlOpMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlOp> {
         return (OpDispenser<Cqld4CqlOp>) switch (target.enumId) {
             case raw -> {
                 CqlD4RawStmtMapper cqlD4RawStmtMapper = new CqlD4RawStmtMapper(adapter, target.targetFunction);
-                OpDispenser<Cqld4CqlSimpleStatement> apply = cqlD4RawStmtMapper.apply(op, spaceFunc);
+                OpDispenser<Cqld4CqlSimpleStatement> apply = cqlD4RawStmtMapper.apply(op, spaceInitF);
                 yield apply;
             }
-            case simple -> new CqlD4CqlSimpleStmtMapper(adapter, target.targetFunction).apply(op, spaceFunc);
-            case prepared -> new CqlD4PreparedStmtMapper(adapter, target).apply(op, spaceFunc);
+            case simple -> new CqlD4CqlSimpleStmtMapper(adapter, target.targetFunction).apply(op, spaceInitF);
+            case prepared -> new CqlD4PreparedStmtMapper(adapter, target).apply(op, spaceInitF);
 
-            case batch -> new CqlD4BatchStmtMapper(adapter, target).apply(op, spaceFunc);
+            case batch -> new CqlD4BatchStmtMapper(adapter, target).apply(op, spaceInitF);
             default ->
                 throw new OpConfigError("Unsupported op type for CQL category of statement forms:" + target.enumId);
         };

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4GremlinOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4GremlinOpMapper.java
@@ -40,7 +40,9 @@ public class Cqld4GremlinOpMapper<CO extends Cqld4ScriptGraphOp> extends Cqld4Ba
 
     @Override
     public Cqld4GremlinOpDispenser apply(ParsedOp op, LongFunction spaceInitF) {
-        return new Cqld4GremlinOpDispenser(adapter, sessionFunc, targetFunction, op);
+        return new Cqld4GremlinOpDispenser(
+            adapter,
+            l -> adapter.getSpaceFunc(op).apply(l).getSession(), targetFunction, op);
     }
 
 }

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBDriverAdapter.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBDriverAdapter.java
@@ -42,7 +42,7 @@ public class DynamoDBDriverAdapter extends BaseDriverAdapter<DynamoDBOp, DynamoD
     @Override
     public OpMapper<DynamoDBOp,DynamoDBSpace> getOpMapper() {
         NBConfiguration adapterConfig = getConfiguration();
-        return new DynamoDBOpMapper(this, adapterConfig, getSpaceCache());
+        return new DynamoDBOpMapper(this, adapterConfig);
     }
 
     @Override

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBOpMapper.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBOpMapper.java
@@ -33,19 +33,18 @@ import java.util.function.LongFunction;
 public class DynamoDBOpMapper implements OpMapper<DynamoDBOp,DynamoDBSpace> {
 
     private final NBConfiguration cfg;
-    private final ConcurrentSpaceCache<DynamoDBSpace> cache;
     private final DriverAdapter adapter;
 
-    public DynamoDBOpMapper(DriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<DynamoDBSpace> cache) {
+    public DynamoDBOpMapper(DynamoDBDriverAdapter adapter, NBConfiguration cfg) {
         this.cfg = cfg;
-        this.cache = cache;
         this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<DynamoDBOp> apply(ParsedOp op, LongFunction<DynamoDBSpace> spaceInitF) {
         int space = op.getStaticConfigOr("space", 0);
-        DynamoDB ddb = cache.get(space).getDynamoDB();
+        LongFunction<DynamoDBSpace> spaceFunc = adapter.getSpaceFunc(op);
+        DynamoDB ddb = spaceFunc.apply(space).getDynamoDB();
 
         /*
          * If the user provides a body element, then they want to provide the JSON or

--- a/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/HttpDriverAdapter.java
+++ b/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/HttpDriverAdapter.java
@@ -56,7 +56,7 @@ public class HttpDriverAdapter extends BaseDriverAdapter<HttpOp, HttpSpace> {
     @Override
     public OpMapper<HttpOp,HttpSpace> getOpMapper() {
         NBConfiguration config = getConfiguration();
-        return new HttpOpMapper(this, config, getSpaceCache());
+        return new HttpOpMapper(this, config);
     }
 
     @Override

--- a/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpMapper.java
+++ b/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpMapper.java
@@ -16,6 +16,7 @@
 
 package io.nosqlbench.adapter.http.core;
 
+import io.nosqlbench.adapter.http.HttpDriverAdapter;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
 import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
@@ -29,19 +30,16 @@ import java.util.function.LongFunction;
 public class HttpOpMapper implements OpMapper<HttpOp,HttpSpace> {
 
     private final NBConfiguration cfg;
-    private final ConcurrentSpaceCache<? extends HttpSpace> spaceCache;
     private final DriverAdapter adapter;
 
-    public HttpOpMapper(DriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<HttpSpace> spaceCache) {
+    public HttpOpMapper(HttpDriverAdapter adapter, NBConfiguration cfg) {
         this.cfg = cfg;
-        this.spaceCache = spaceCache;
         this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<HttpOp> apply(ParsedOp op, LongFunction<HttpSpace> spaceInitF) {
         LongFunction<String> spaceNameF = op.getAsFunctionOr("space", "default");
-        LongFunction<HttpSpace> spaceFunc = l -> spaceCache.get(l);
-        return new HttpOpDispenser(adapter, spaceFunc, op);
+        return new HttpOpDispenser(adapter, spaceInitF, op);
     }
 }

--- a/nb-adapters/adapter-http/src/test/java/io/nosqlbench/adapter/http/HttpOpMapperTest.java
+++ b/nb-adapters/adapter-http/src/test/java/io/nosqlbench/adapter/http/HttpOpMapperTest.java
@@ -49,8 +49,7 @@ public class HttpOpMapperTest {
         HttpOpMapperTest.cfg = HttpSpace.getConfigModel().apply(Map.of());
         HttpOpMapperTest.adapter = new HttpDriverAdapter(new TestComponent("parent","parent"), NBLabels.forKV());
         HttpOpMapperTest.adapter.applyConfig(HttpOpMapperTest.cfg);
-        ConcurrentSpaceCache<HttpSpace> spaceCache = HttpOpMapperTest.adapter.getSpaceCache();
-        HttpOpMapperTest.mapper = new HttpOpMapper(HttpOpMapperTest.adapter, HttpOpMapperTest.cfg, spaceCache);
+        HttpOpMapperTest.mapper = new HttpOpMapper(HttpOpMapperTest.adapter, HttpOpMapperTest.cfg);
     }
 
     private static ParsedOp parsedOpFor(final String yaml) {

--- a/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaDriverAdapter.java
+++ b/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaDriverAdapter.java
@@ -39,9 +39,8 @@ public class KafkaDriverAdapter extends BaseDriverAdapter<KafkaOp, KafkaSpace> {
 
     @Override
     public OpMapper<KafkaOp,KafkaSpace> getOpMapper() {
-        ConcurrentSpaceCache<KafkaSpace> spaceCache = getSpaceCache();
         NBConfiguration adapterConfig = getConfiguration();
-        return new KafkaOpMapper(this, adapterConfig, spaceCache);
+        return new KafkaOpMapper(this, adapterConfig);
     }
 
 

--- a/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaOpMapper.java
+++ b/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaOpMapper.java
@@ -36,11 +36,9 @@ public class KafkaOpMapper implements OpMapper<KafkaOp,KafkaSpace> {
 
     private final static Logger logger = LogManager.getLogger(KafkaOpMapper.class);
 
-    private final ConcurrentSpaceCache<KafkaSpace> spaceCache;
     private final DriverAdapter<KafkaOp,KafkaSpace> adapter;
 
-    public KafkaOpMapper(DriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<KafkaSpace> spaceCache) {
-        this.spaceCache = spaceCache;
+    public KafkaOpMapper(DriverAdapter adapter, NBConfiguration cfg) {
         this.adapter = adapter;
     }
 

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoOpMapper.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoOpMapper.java
@@ -36,12 +36,9 @@ public class MongoOpMapper<MC extends MongoDirectCommandOp> implements OpMapper<
 
     private final MongodbDriverAdapter adapter;
     private final NBConfiguration configuration;
-    private final ConcurrentSpaceCache<MongoSpace> spaceCache;
 
-    public MongoOpMapper(MongodbDriverAdapter adapter, NBConfiguration cfg,
-                         ConcurrentSpaceCache<MongoSpace> spaceCache) {
+    public MongoOpMapper(MongodbDriverAdapter adapter, NBConfiguration cfg) {
         this.configuration = cfg;
-        this.spaceCache = spaceCache;
         this.adapter = adapter;
     }
 

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongodbDriverAdapter.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongodbDriverAdapter.java
@@ -41,7 +41,7 @@ public class MongodbDriverAdapter extends BaseDriverAdapter<MongoOp<?>, MongoSpa
 
     @Override
     public OpMapper<MongoOp<?>,MongoSpace> getOpMapper() {
-        return new MongoOpMapper(this, getConfiguration(), getSpaceCache());
+        return new MongoOpMapper(this, getConfiguration());
     }
 
     @Override

--- a/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JDriverAdapter.java
+++ b/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JDriverAdapter.java
@@ -38,7 +38,7 @@ public class Neo4JDriverAdapter extends BaseDriverAdapter<Neo4JBaseOp, Neo4JSpac
 
     @Override
     public OpMapper<Neo4JBaseOp,Neo4JSpace> getOpMapper() {
-        return new Neo4JOpMapper(this, getSpaceCache());
+        return new Neo4JOpMapper(this);
     }
 
     @Override

--- a/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JOpMapper.java
+++ b/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JOpMapper.java
@@ -33,7 +33,7 @@ import java.util.function.LongFunction;
 public class Neo4JOpMapper implements OpMapper<Neo4JBaseOp,Neo4JSpace> {
     private final Neo4JDriverAdapter adapter;
 
-    public Neo4JOpMapper(Neo4JDriverAdapter adapter, ConcurrentSpaceCache<Neo4JSpace> cache) {
+    public Neo4JOpMapper(Neo4JDriverAdapter adapter) {
         this.adapter = adapter;
     }
 

--- a/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarDriverAdapter.java
+++ b/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarDriverAdapter.java
@@ -44,9 +44,8 @@ public class PulsarDriverAdapter extends BaseDriverAdapter<PulsarOp, PulsarSpace
 
     @Override
     public OpMapper<PulsarOp,PulsarSpace> getOpMapper() {
-        ConcurrentSpaceCache<PulsarSpace> spaceCache = getSpaceCache();
         NBConfiguration adapterConfig = getConfiguration();
-        return new PulsarOpMapper(this, adapterConfig, spaceCache);
+        return new PulsarOpMapper(this, adapterConfig);
     }
 
     @Override

--- a/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarOpMapper.java
+++ b/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarOpMapper.java
@@ -37,20 +37,18 @@ public class PulsarOpMapper implements OpMapper<PulsarOp,PulsarSpace> {
     private final static Logger logger = LogManager.getLogger(PulsarOpMapper.class);
 
     private final NBConfiguration cfg;
-    private final ConcurrentSpaceCache<PulsarSpace> spaceCache;
     private final PulsarDriverAdapter adapter;
 
-    public PulsarOpMapper(PulsarDriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<PulsarSpace> spaceCache) {
+    public PulsarOpMapper(PulsarDriverAdapter adapter, NBConfiguration cfg) {
         this.cfg = cfg;
-        this.spaceCache = spaceCache;
-        this.adapter = adapter;
+       this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<PulsarOp> apply(ParsedOp op, LongFunction<PulsarSpace> spaceInitF) {
         int spaceName = op.getStaticConfigOr("space", 0);
 //        PulsarSpace pulsarSpace = spaceCache.get(spaceName);
-        PulsarSpace pulsarSpace = adapter.getSpaceCache().get(spaceName);
+        PulsarSpace pulsarSpace = adapter.getSpaceFunc(op).apply(spaceName);
 
         /*
          * If the user provides a body element, then they want to provide the JSON or

--- a/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JDriverAdapter.java
+++ b/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JDriverAdapter.java
@@ -42,9 +42,7 @@ public class S4JDriverAdapter extends BaseDriverAdapter<S4JOp, S4JSpace> {
 
     @Override
     public OpMapper<S4JOp,S4JSpace> getOpMapper() {
-        ConcurrentSpaceCache<? extends S4JSpace> spaceCache = getSpaceCache();
-        NBConfiguration adapterConfig = getConfiguration();
-        return new S4JOpMapper(this, adapterConfig, spaceCache);
+        return new S4JOpMapper(this);
     }
 
     @Override

--- a/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JOpMapper.java
+++ b/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JOpMapper.java
@@ -37,20 +37,14 @@ public class S4JOpMapper implements OpMapper<S4JOp,S4JSpace> {
 
     private final static Logger logger = LogManager.getLogger(S4JOpMapper.class);
 
-    private final NBConfiguration cfg;
-    private final ConcurrentSpaceCache<? extends S4JSpace> spaceCache;
-    private final DriverAdapter adapter;
+    private final S4JDriverAdapter adapter;
 
-    public S4JOpMapper(DriverAdapter adapter, NBConfiguration cfg, ConcurrentSpaceCache<? extends S4JSpace> spaceCache) {
-        this.cfg = cfg;
-        this.spaceCache = spaceCache;
+    public S4JOpMapper(S4JDriverAdapter adapter) {
         this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<S4JOp> apply(ParsedOp op, LongFunction<S4JSpace> spaceInitF) {
-        int spaceIdx = op.getStaticConfigOr("space", 0);
-        S4JSpace s4jSpace = spaceCache.get(spaceIdx);
 
         /*
          * If the user provides a body element, then they want to provide the JSON or
@@ -65,9 +59,9 @@ public class S4JOpMapper implements OpMapper<S4JOp,S4JSpace> {
 
             return switch (opType.enumId) {
                 case MessageProduce ->
-                    new MessageProducerOpDispenser(adapter, op, opType.targetFunction, s4jSpace);
+                    new MessageProducerOpDispenser(adapter, op, opType.targetFunction);
                 case MessageConsume ->
-                    new MessageConsumerOpDispenser(adapter, op, opType.targetFunction, s4jSpace);
+                    new MessageConsumerOpDispenser(adapter, op, opType.targetFunction);
             };
         }
     }

--- a/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutDriverAdapter.java
+++ b/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutDriverAdapter.java
@@ -49,8 +49,7 @@ public class StdoutDriverAdapter extends BaseDriverAdapter<StdoutOp, StdoutSpace
 
     @Override
     public OpMapper<StdoutOp,StdoutSpace> getOpMapper() {
-        ConcurrentSpaceCache<StdoutSpace> ctxCache = getSpaceCache();
-        return new StdoutOpMapper(this, ctxCache);
+        return new StdoutOpMapper(this);
     }
 
     @Override

--- a/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpMapper.java
+++ b/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpMapper.java
@@ -28,11 +28,9 @@ import java.util.function.LongFunction;
 
 public class StdoutOpMapper implements OpMapper<StdoutOp,StdoutSpace> {
 
-    private final ConcurrentSpaceCache<? extends StdoutSpace> spaceCache;
     private final DriverAdapter adapter;
 
-    public StdoutOpMapper(DriverAdapter adapter, ConcurrentSpaceCache<? extends StdoutSpace> spaceCache) {
-        this.spaceCache = spaceCache;
+    public StdoutOpMapper(DriverAdapter adapter) {
         this.adapter = adapter;
     }
 

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientDriverAdapter.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientDriverAdapter.java
@@ -51,7 +51,7 @@ public class TcpClientDriverAdapter extends BaseDriverAdapter<TcpClientOp, TcpCl
     @Override
     public OpMapper<TcpClientOp,TcpClientAdapterSpace> getOpMapper() {
 
-        return new TcpClientOpMapper(this,getSpaceCache());
+        return new TcpClientOpMapper(this);
     }
 
     @Override

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpMapper.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpMapper.java
@@ -26,19 +26,17 @@ import java.util.function.LongFunction;
 
 public class TcpClientOpMapper implements OpMapper<TcpClientOp,TcpClientAdapterSpace> {
 
-    private final ConcurrentSpaceCache<TcpClientAdapterSpace> ctxcache;
     private final TcpClientDriverAdapter adapter;
 
 
-    public TcpClientOpMapper(TcpClientDriverAdapter adapter, ConcurrentSpaceCache<TcpClientAdapterSpace> ctxcache) {
-        this.ctxcache = ctxcache;
+    public TcpClientOpMapper(TcpClientDriverAdapter adapter) {
         this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<TcpClientOp> apply(ParsedOp op, LongFunction<TcpClientAdapterSpace> spaceInitF) {
         LongFunction<String> spacefunc = op.getAsFunctionOr("space", "default");
-        LongFunction<TcpClientAdapterSpace> ctxfunc = (cycle) -> ctxcache.get(cycle);
+        LongFunction<TcpClientAdapterSpace> ctxfunc = adapter.getSpaceFunc(op);
         return new TcpClientOpDispenser(adapter,op,ctxfunc);
     }
 

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerDriverAdapter.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerDriverAdapter.java
@@ -49,7 +49,7 @@ public class TcpServerDriverAdapter extends BaseDriverAdapter<TcpServerOp, TcpSe
 
     @Override
     public OpMapper<TcpServerOp,TcpServerAdapterSpace> getOpMapper() {
-        return new TcpServerOpMapper(this,getSpaceCache());
+        return new TcpServerOpMapper(this);
     }
 
     @Override

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpMapper.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpMapper.java
@@ -26,19 +26,17 @@ import java.util.function.LongFunction;
 
 public class TcpServerOpMapper implements OpMapper<TcpServerOp,TcpServerAdapterSpace> {
 
-    private final ConcurrentSpaceCache<TcpServerAdapterSpace> ctxcache;
     private final TcpServerDriverAdapter adapter;
 
 
-    public TcpServerOpMapper(TcpServerDriverAdapter adapter, ConcurrentSpaceCache<TcpServerAdapterSpace> ctxcache) {
-        this.ctxcache = ctxcache;
+    public TcpServerOpMapper(TcpServerDriverAdapter adapter) {
         this.adapter = adapter;
     }
 
     @Override
     public OpDispenser<TcpServerOp> apply(ParsedOp op, LongFunction<TcpServerAdapterSpace> spaceInitF) {
         LongFunction<String> spacefunc = op.getAsFunctionOr("space", "default");
-        LongFunction<TcpServerAdapterSpace> ctxfunc = (cycle) -> ctxcache.get(cycle);
+        LongFunction<TcpServerAdapterSpace> ctxfunc = adapter.getSpaceFunc(op);
         return new TcpServerOpDispenser(adapter,op,ctxfunc);
     }
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongFunction;
 
 /**
  * See {@link OpDispenser} for details on how to use this type.
@@ -65,6 +66,7 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>,SPACE extends Space>
     private Timer errorTimer;
     private final String[] timerStarts;
     private final String[] timerStops;
+    protected LongFunction<? extends SPACE> spaceF;
 
     /**
      * package imports used with "verifiers" or "expected-result" are accumulated here
@@ -83,6 +85,7 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>,SPACE extends Space>
         super(adapter);
         opName = op.getName();
         this.adapter = adapter;
+        this.spaceF = adapter.getSpaceFunc(op);
         labels = op.getLabels();
 
         this.timerStarts = op.takeOptionalStaticValue(START_TIMERS, String.class)

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpMapper.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpMapper.java
@@ -82,7 +82,7 @@ import java.util.function.LongFunction;
  *            generally something that implements {@link Runnable}.
  */
 public interface OpMapper<OPTYPE extends CycleOp<?>, SPACETYPE extends Space>
-    extends BiFunction<ParsedOp, LongFunction<SPACETYPE>, OpDispenser<OPTYPE>> {
+    extends BiFunction<ParsedOp, LongFunction<SPACETYPE>, OpDispenser<? extends OPTYPE>> {
 
     /**
      * Interrogate the parsed command, and provide a new

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/DriverAdapter.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/DriverAdapter.java
@@ -131,22 +131,7 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
         return List.of(f -> f);
     }
 
-    /**
-     * The cache of all objects needed within a single instance
-     * of a DriverAdapter which are not operations. These are generally
-     * things needed by operations, or things needed during the
-     * construction of operations.
-     *
-     * See {@link ConcurrentIndexCache} for details on when and how to use this function.
-     *
-     * <p>During Adapter Initialization, Op Mapping, Op Synthesis, or Op Execution,
-     * you may need access to the objects in (the or a) space cache. You can build the
-     * type of context needed and then provide this function to provide new instances
-     * when needed.</p>
-     *
-     * @return A cache of named objects
-     */
-    ConcurrentSpaceCache<SPACETYPE> getSpaceCache();
+//    ConcurrentSpaceCache<SPACETYPE> getSpaceCache();
 
     /**
      * This method allows each driver adapter to create named state which is automatically
@@ -209,5 +194,27 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
         return this.getClass().getAnnotation(Service.class).maturity();
     }
 
-    LongFunction<SPACETYPE> getSpaceFunc(ParsedOp pop);
+    /**
+     * <p>The cache of all objects needed within a single instance
+     * of a DriverAdapter which are not operations. These are generally
+     * things needed by operations, or things needed during the
+     * construction of operations.</p>
+     *
+     * <p>During Adapter Initialization, Op Mapping, Op Synthesis, or Op Execution,
+     * you may need access to the objects in (the or a) space cache. You can build the
+     * type of context needed and then provide this function to provide new instances
+     * when needed.</p>
+     *
+     * <p>The function returned by this method is specialized to the space mapping
+     * logic in the op template. Specifically, it uses whatever binding is set on a given
+     * op template for the <em>space</em> op field. If none are provided, then this
+     * becomes a short-circuit for the default '0'. If a non-numeric binding is provided,
+     * then an interstitial mapping is added which converts the {@link Object#toString()}
+     * value to ordinals using a hash map. This is less optimal by far than using
+     * any binding that produces a {@link Number}.</p>
+     *
+     * @return A cache of named objects
+     */
+    public LongFunction<SPACETYPE> getSpaceFunc(ParsedOp pop);
+
 }

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityimpl/uniform/StandardActivity.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityimpl/uniform/StandardActivity.java
@@ -265,16 +265,8 @@ public class StandardActivity<R extends java.util.function.LongFunction, S> exte
         for (Map.Entry<String, DriverAdapter<CycleOp<?>,Space>> entry : adapters.entrySet()) {
             String adapterName = entry.getKey();
             DriverAdapter<?, ?> adapter = entry.getValue();
-            for (Space space : adapter.getSpaceCache()) {
-                if (space instanceof AutoCloseable autoCloseable) {
-                    try {
-                        // TODO This should be invariant now, remove conditional?
-                        autoCloseable.close();
-                    } catch (Exception e) {
-                        throw new RuntimeException("Error while shutting down state space for " +
-                            "adapter=" + adapterName + ", space=" + space.getName() + ": " + e, e);
-                    }
-                }
+            if (adapter instanceof AutoCloseable autoCloseable) {
+                adapter.close();
             }
         }
     }


### PR DESCRIPTION
closes #2068

This change set fixes a hole in the space caching APIs.
Since space bindings can be set at the op-template level, any code which was bypassing this was canonically wrong. They were either 1) getting a static space before op synthesis or 2) using the space cache directly (without the name mapping layer).

The API was modified to disable bypassing the cache binding, and all clients were adjusted to use the updated path.

There are some changes in the streaming adapters which were not using the space binding rules as expected, so these were updated. These changes will need to be further reviewed with streaming devs before they use them for testing in newer NB versions.