### PR TITLE
S4J does not depend on Conscrypt

### DIFF
--- a/nb-adapters/adapter-s4j/pom.xml
+++ b/nb-adapters/adapter-s4j/pom.xml
@@ -76,13 +76,13 @@
             <version>2.10.1</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.conscrypt/conscrypt-openjdk -->
+        <!-- https://mvnrepository.com/artifact/org.conscrypt/conscrypt-openjdk
         <dependency>
             <groupId>org.conscrypt</groupId>
             <artifactId>conscrypt-openjdk</artifactId>
             <version>2.5.2</version>
             <classifier>${os.detected.classifier}</classifier>
-        </dependency>
+        </dependency> -->
 
     </dependencies>
 


### PR DESCRIPTION
Solves #2059 - it turns out the dependency is not needed.

I validated but looking into our `datastax/openmessaging-benchmarks` use of S4J