### PR TITLE
Make listings similar to command syntax

### DIFF
--- a/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIScenarios.java
+++ b/nb-engine/nb-engine-cli/src/main/java/io/nosqlbench/engine/cli/NBCLIScenarios.java
@@ -44,8 +44,8 @@ public class NBCLIScenarios {
 
         System.out.println(
             "## To include examples, add --include=examples\n" +
-                "## To copy any of these to your local directory, use\n" +
-                "## --include=examples --copy=examplename\n"
+            "## To copy any of these to your local directory, use\n" +
+            "## --include=examples --copy=examplename\n"
         );
 
     }

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/WorkloadDesc.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/WorkloadDesc.java
@@ -91,20 +91,17 @@ public class WorkloadDesc implements Comparable<WorkloadDesc> {
         }
 
         if (includeScenarios) {
-            sb.append("# workload found in ");
+            sb.append("# ");
         }
-        sb.append(getYamlPath()).append("\n");
+        sb.append("workload=").append(getYamlPath().substring(1)).append("\n");
 
 
         if (includeScenarios) {
             sb.append("    # scenarios:\n");
 
             for (String scenario : getScenarioNames()) {
-                sb.append("    nb ")
-                    .append(this.getWorkloadName())
-                    .append(" ").append(scenario).append("\n");
+                sb.append("    ").append(scenario).append("\n");
             }
-
 
             if (templates.size() > 0) {
                 sb.append("        # defaults\n");


### PR DESCRIPTION
closes: #2080 

The listings for `--list-workloads` and `--list-scenarios` were subtly different from current cli syntax which made users think that the examples were missing.