### PR TITLE
many-sessions improvements, type fixes, more javadocs

### DIFF
--- a/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpOpMapper.java
+++ b/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/AmqpOpMapper.java
@@ -19,12 +19,10 @@ package io.nosqlbench.adapter.amqp;
 import io.nosqlbench.adapter.amqp.dispensers.AmqpMsgRecvOpDispenser;
 import io.nosqlbench.adapter.amqp.dispensers.AmqpMsgSendOpDispenser;
 import io.nosqlbench.adapter.amqp.ops.AmqpTimeTrackOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
 import org.apache.logging.log4j.LogManager;
@@ -45,7 +43,7 @@ public class AmqpOpMapper implements OpMapper<AmqpTimeTrackOp,AmqpSpace> {
     }
 
     @Override
-        public OpDispenser<AmqpTimeTrackOp> apply(ParsedOp op, LongFunction spaceInitF) {
+        public OpDispenser<AmqpTimeTrackOp> apply(NBComponent adapterC, ParsedOp op, LongFunction spaceInitF) {
     //public OpDispenser<AmqpTimeTrackOp> apply(ParsedOp op, LongFunction<AmqpTimeTrackOp> spaceInitF) {
         int spaceName = op.getStaticConfigOr("space", 0);
 

--- a/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/dispensers/AmqpBaseOpDispenser.java
+++ b/nb-adapters/adapter-amqp/src/main/java/io/nosqlbench/adapter/amqp/dispensers/AmqpBaseOpDispenser.java
@@ -23,7 +23,6 @@ import io.nosqlbench.adapter.amqp.exception.AmqpAdapterUnexpectedException;
 import io.nosqlbench.adapter.amqp.ops.AmqpTimeTrackOp;
 import io.nosqlbench.adapter.amqp.util.AmqpAdapterMetrics;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
@@ -49,7 +48,7 @@ public abstract  class AmqpBaseOpDispenser extends BaseOpDispenser<AmqpTimeTrack
     protected AmqpBaseOpDispenser(final AmqpDriverAdapter adapter,
                                   final ParsedOp op) {
 
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         parsedOp = op;
 
         amqpAdapterMetrics = new AmqpAdapterMetrics(this, this);

--- a/nb-adapters/adapter-azure-aisearch/src/main/java/io/nosqlbench/adapter/azureaisearch/AzureAISearchOpMapper.java
+++ b/nb-adapters/adapter-azure-aisearch/src/main/java/io/nosqlbench/adapter/azureaisearch/AzureAISearchOpMapper.java
@@ -16,7 +16,7 @@
 
 package io.nosqlbench.adapter.azureaisearch;
 
-import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -54,6 +54,7 @@ public class AzureAISearchOpMapper implements OpMapper<AzureAISearchBaseOp<?,?>,
      * Given an instance of a {@link ParsedOp} returns the appropriate
      * {@link AzureAISearchBaseOpDispenser} subclass.
      *
+     * @param adapterC
      * @param op
      *     The {@link ParsedOp} to be evaluated
      * @param spaceInitF
@@ -61,7 +62,7 @@ public class AzureAISearchOpMapper implements OpMapper<AzureAISearchBaseOp<?,?>,
      *     the op type
      */
     @Override
-    public OpDispenser<AzureAISearchBaseOp<?,?>> apply(ParsedOp op, LongFunction<AzureAISearchSpace> spaceInitF) {
+    public OpDispenser<AzureAISearchBaseOp<?,?>> apply(NBComponent adapterC, ParsedOp op, LongFunction<AzureAISearchSpace> spaceInitF) {
 
         TypeAndTarget<AzureAISearchOpType, String> typeAndTarget = op.getTypeAndTarget(AzureAISearchOpType.class,
             String.class, "type", "target");

--- a/nb-adapters/adapter-azure-aisearch/src/main/java/io/nosqlbench/adapter/azureaisearch/opsdispenser/AzureAISearchBaseOpDispenser.java
+++ b/nb-adapters/adapter-azure-aisearch/src/main/java/io/nosqlbench/adapter/azureaisearch/opsdispenser/AzureAISearchBaseOpDispenser.java
@@ -39,7 +39,7 @@ public abstract class AzureAISearchBaseOpDispenser<REQUEST,RESULT>
 	@SuppressWarnings("rawtypes")
 	protected AzureAISearchBaseOpDispenser(AzureAISearchDriverAdapter adapter, ParsedOp op,
 			LongFunction<String> targetF) {
-		super((DriverAdapter) adapter, op);
+		super((DriverAdapter) adapter, op, adapter.getSpaceFunc(op));
 		this.azureAISearchSpaceFunction = adapter.getSpaceFunc(op);
 		this.clientFunction = (long l) -> {
 			try {
@@ -53,10 +53,6 @@ public abstract class AzureAISearchBaseOpDispenser<REQUEST,RESULT>
 		this.opF = createOpFunc(paramF, this.clientFunction, op, targetF);
 	}
 
-	protected AzureAISearchDriverAdapter getDriverAdapter() {
-		return (AzureAISearchDriverAdapter) adapter;
-	}
-
 	public abstract LongFunction<REQUEST> getParamFunc(LongFunction<SearchIndexClient> clientF, ParsedOp op,
 			LongFunction<String> targetF);
 
@@ -64,8 +60,8 @@ public abstract class AzureAISearchBaseOpDispenser<REQUEST,RESULT>
 			LongFunction<SearchIndexClient> clientF, ParsedOp op, LongFunction<String> targetF);
 
 	@Override
-	public AzureAISearchBaseOp<REQUEST,RESULT> getOp(long value) {
-		return opF.apply(value);
+	public AzureAISearchBaseOp<REQUEST,RESULT> getOp(long cycle) {
+		return opF.apply(cycle);
 	}
 
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/Cqld4Space.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/Cqld4Space.java
@@ -84,6 +84,7 @@ public class Cqld4Space extends BaseSpace<Cqld4Space> {
         // stop insights for testing
         OptionsMap defaults = new OptionsMap();
         defaults.put(TypedDriverOption.MONITOR_REPORTING_ENABLED, false); // We don't need to do this every time we run a test or sanity check
+        defaults.put(TypedDriverOption.SESSION_LEAK_THRESHOLD, 100000000);
         DriverConfigLoader dcl = DriverConfigLoader.fromMap(defaults);
 
         // add streamlined cql parameters

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/CqlD4BatchStmtDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/CqlD4BatchStmtDispenser.java
@@ -16,17 +16,13 @@
 
 package io.nosqlbench.adapter.cqld4.opdispensers;
 
-import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.*;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
-import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.optionhelpers.BatchTypeEnum;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlBatchStatement;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.BaseSpace;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import org.jetbrains.annotations.NotNull;
 
@@ -50,7 +46,7 @@ public class CqlD4BatchStmtDispenser extends Cqld4CqlBaseOpDispenser<Cqld4CqlBat
         this.subop = subop;
         this.opfunc = createStmtFunc(op, subopDispenser);
         this.submapper = adapter.getOpMapper();
-        subopDispenser = submapper.apply(subop, adapter.getSpaceFunc(op));
+        subopDispenser = submapper.apply(this, subop, adapter.getSpaceFunc(op));
 
     }
 
@@ -87,10 +83,10 @@ public class CqlD4BatchStmtDispenser extends Cqld4CqlBaseOpDispenser<Cqld4CqlBat
     }
 
     @Override
-    public Cqld4CqlBatchStatement getOp(long value) {
-        Statement bstmt = opfunc.apply(value);
+    public Cqld4CqlBatchStatement getOp(long cycle) {
+        Statement bstmt = opfunc.apply(cycle);
         return new Cqld4CqlBatchStatement(
-            sessionF.apply(value),
+            sessionF.apply(cycle),
             (BatchStatement) bstmt,
             getMaxPages(),
             getMaxLwtRetries(),

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4BaseOpDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4BaseOpDispenser.java
@@ -28,7 +28,6 @@ import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.instruments.CqlOpMetrics;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
@@ -40,7 +39,6 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Map;
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public abstract class Cqld4BaseOpDispenser<T extends Cqld4BaseOp<?>> extends BaseOpDispenser<T, Cqld4Space> implements CqlOpMetrics {
@@ -57,7 +55,7 @@ public abstract class Cqld4BaseOpDispenser<T extends Cqld4BaseOp<?>> extends Bas
 
     public Cqld4BaseOpDispenser(Cqld4DriverAdapter adapter,
                                 ParsedOp op) {
-        super((DriverAdapter<? extends T, ? extends Cqld4Space>) adapter, op);
+        super((DriverAdapter<? extends T, ? extends Cqld4Space>) adapter, op, adapter.getSpaceFunc(op));
         this.sessionF = l -> adapter.getSpaceFunc(op).apply(l).getSession();
         this.maxpages = op.getStaticConfigOr("maxpages", 1);
         this.isRetryReplace = op.getStaticConfigOr("retryreplace", false);

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4CqlBaseOpDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4CqlBaseOpDispenser.java
@@ -30,5 +30,5 @@ public abstract class Cqld4CqlBaseOpDispenser<T extends Cqld4CqlOp> extends Cqld
     }
 
     @Override
-    public abstract T getOp(long value);
+    public abstract T getOp(long cycle);
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4FluentGraphOpDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4FluentGraphOpDispenser.java
@@ -55,14 +55,14 @@ public class Cqld4FluentGraphOpDispenser extends Cqld4BaseOpDispenser<Cqld4Fluen
     }
 
     @Override
-    public Cqld4FluentGraphOp getOp(long value) {
-        String graphname = graphnameFunc.apply(value);
+    public Cqld4FluentGraphOp getOp(long cycle) {
+        String graphname = graphnameFunc.apply(cycle);
         Script script = tlScript.get();
-        Map<String, Object> allMap = virtdataBindings.getAllMap(value);
+        Map<String, Object> allMap = virtdataBindings.getAllMap(cycle);
         allMap.forEach((k,v) -> script.getBinding().setVariable(k,v));
         GraphTraversal<Vertex,Vertex> v = (GraphTraversal<Vertex, Vertex>) script.run();
         FluentGraphStatement fgs = new FluentGraphStatementBuilder(v).setGraphName(graphname).build();
-        return new Cqld4FluentGraphOp(sessionF.apply(value),fgs);
+        return new Cqld4FluentGraphOp(sessionF.apply(cycle),fgs);
     }
 
 

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4GremlinOpDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4GremlinOpDispenser.java
@@ -22,10 +22,8 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4ScriptGraphOp;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 
 import java.util.Optional;
@@ -39,7 +37,7 @@ public class Cqld4GremlinOpDispenser extends BaseOpDispenser<Cqld4BaseOp<?>, Cql
 
     public Cqld4GremlinOpDispenser(Cqld4DriverAdapter adapter,
                                    LongFunction<CqlSession> sessionFunc, LongFunction<String> targetFunction, ParsedOp cmd) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.sessionFunc = sessionFunc;
         this.diagFunc = cmd.getAsFunctionOr("diag", 0L);
 
@@ -59,12 +57,12 @@ public class Cqld4GremlinOpDispenser extends BaseOpDispenser<Cqld4BaseOp<?>, Cql
     }
 
     @Override
-    public Cqld4ScriptGraphOp getOp(long value) {
-        ScriptGraphStatement stmt = stmtFunc.apply(value);
-        if (diagFunc.apply(value)>0L) {
+    public Cqld4ScriptGraphOp getOp(long cycle) {
+        ScriptGraphStatement stmt = stmtFunc.apply(cycle);
+        if (diagFunc.apply(cycle)>0L) {
             System.out.println("## GREMLIN DIAG: ScriptGraphStatement on graphname(" + stmt.getGraphName() + "):\n" + stmt.getScript());
         }
-        return new Cqld4ScriptGraphOp(sessionFunc.apply(value), stmt);
+        return new Cqld4ScriptGraphOp(sessionFunc.apply(cycle), stmt);
     }
 
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4RawStmtDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4RawStmtDispenser.java
@@ -47,10 +47,10 @@ public class Cqld4RawStmtDispenser extends Cqld4CqlBaseOpDispenser<Cqld4CqlSimpl
     }
 
     @Override
-    public Cqld4CqlSimpleStatement getOp(long value) {
+    public Cqld4CqlSimpleStatement getOp(long cycle) {
         return new Cqld4CqlSimpleStatement(
-            sessionF.apply(value),
-            (SimpleStatement) stmtFunc.apply(value),
+            sessionF.apply(cycle),
+            (SimpleStatement) stmtFunc.apply(cycle),
             getMaxPages(),
             isRetryReplace(),
             getMaxLwtRetries(),

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4SimpleCqlStmtDispenser.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opdispensers/Cqld4SimpleCqlStmtDispenser.java
@@ -44,10 +44,10 @@ public class Cqld4SimpleCqlStmtDispenser extends Cqld4CqlBaseOpDispenser<Cqld4Cq
     }
 
     @Override
-    public Cqld4CqlSimpleStatement getOp(long value) {
+    public Cqld4CqlSimpleStatement getOp(long cycle) {
         return new Cqld4CqlSimpleStatement(
-            this.sessionF.apply(value),
-            (SimpleStatement) stmtFunc.apply(value),
+            this.sessionF.apply(cycle),
+            (SimpleStatement) stmtFunc.apply(cycle),
             getMaxPages(),
             isRetryReplace(),
             getMaxLwtRetries(),

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4BatchStmtMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4BatchStmtMapper.java
@@ -25,6 +25,7 @@ import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.List;
 import java.util.function.LongFunction;
@@ -40,10 +41,10 @@ public class CqlD4BatchStmtMapper<RESULT extends List<? extends Row>> extends Cq
     }
 
     @Override
-    public OpDispenser<Cqld4CqlBatchStatement> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
+    public OpDispenser<Cqld4CqlBatchStatement> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
         ParsedOp subop = op.getAsSubOp("op_template", ParsedOp.SubOpNaming.ParentAndSubKey);
         int repeat = op.getStaticValue("repeat");
-        OpDispenser<Cqld4CqlOp> od = new Cqld4CqlOpMapper(adapter).apply(op, spaceInitF);
+        OpDispenser<Cqld4CqlOp> od = new Cqld4CqlOpMapper(adapter).apply(adapterC, op, spaceInitF);
         return new CqlD4BatchStmtDispenser(adapter, op, repeat, subop, od);
     }
 

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4CqlSimpleStmtMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4CqlSimpleStmtMapper.java
@@ -19,10 +19,10 @@ package io.nosqlbench.adapter.cqld4.opmappers;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.opdispensers.Cqld4SimpleCqlStmtDispenser;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlSimpleStatement;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -36,7 +36,7 @@ public class CqlD4CqlSimpleStmtMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlSimpl
     }
 
     @Override
-    public OpDispenser<Cqld4CqlSimpleStatement> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
+    public OpDispenser<Cqld4CqlSimpleStatement> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
         return new Cqld4SimpleCqlStmtDispenser(adapter, targetFunction, op);
     }
 

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4PreparedStmtMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4PreparedStmtMapper.java
@@ -16,19 +16,14 @@
 
 package io.nosqlbench.adapter.cqld4.opmappers;
 
-import com.datastax.oss.driver.api.core.CqlSession;
 import io.nosqlbench.adapter.cqld4.*;
 import io.nosqlbench.adapter.cqld4.opdispensers.Cqld4PreparedStmtDispenser;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlPreparedStatement;
 import io.nosqlbench.adapter.cqld4.processors.CqlFieldCaptureProcessor;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.params.ParamsParser;
 import io.nosqlbench.nb.api.errors.BasicError;
 import io.nosqlbench.virtdata.core.templates.ParsedTemplateString;
@@ -49,7 +44,11 @@ public class CqlD4PreparedStmtMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlPrepar
     }
 
     @Override
-    public OpDispenser<Cqld4CqlPreparedStatement> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
+    public OpDispenser<Cqld4CqlPreparedStatement> apply(
+        NBComponent adapterC,
+        ParsedOp op,
+        LongFunction<Cqld4Space> spaceInitF
+    ) {
         ParsedTemplateString stmtTpl = op.getAsTemplate(target.field).orElseThrow(() -> new BasicError(
             "No statement was found in the op template:" + op
         ));
@@ -69,7 +68,7 @@ public class CqlD4PreparedStmtMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlPrepar
             });
         });
 
-        return new Cqld4PreparedStmtDispenser(adapter, op, stmtTpl, processors);
+        return new Cqld4PreparedStmtDispenser(adapter, op, stmtTpl, processors, spaceInitF);
     }
 
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4RainbowTableMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4RainbowTableMapper.java
@@ -18,14 +18,11 @@ package io.nosqlbench.adapter.cqld4.opmappers;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
-import io.nosqlbench.adapter.cqld4.Cqld4Space;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4RainbowTableOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.OpMapper;
 import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -44,7 +41,7 @@ public class CqlD4RainbowTableMapper<CO extends Cqld4RainbowTableOp> extends Cql
     }
 
     @Override
-    public OpDispenser<Cqld4RainbowTableOp> apply(ParsedOp op, LongFunction spaceInitF) {
+    public OpDispenser<Cqld4RainbowTableOp> apply(NBComponent adapterC, ParsedOp op, LongFunction spaceInitF) {
         return null;
 //        return new CqlD4RainbowTableDispenser(adapter, sessionFunc,targetFunction, op);
     }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4RawStmtMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/CqlD4RawStmtMapper.java
@@ -19,10 +19,10 @@ package io.nosqlbench.adapter.cqld4.opmappers;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.opdispensers.Cqld4RawStmtDispenser;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlSimpleStatement;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -35,7 +35,7 @@ public class CqlD4RawStmtMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlSimpleState
     }
 
     @Override
-    public OpDispenser<Cqld4CqlSimpleStatement> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
+    public OpDispenser<Cqld4CqlSimpleStatement> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
         return new Cqld4RawStmtDispenser(adapter, targetFunction,op);
     }
 

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4BaseOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4BaseOpMapper.java
@@ -16,14 +16,13 @@
 
 package io.nosqlbench.adapter.cqld4.opmappers;
 
-import com.datastax.oss.driver.api.core.CqlSession;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,5 +38,5 @@ public abstract class Cqld4BaseOpMapper<T extends Cqld4BaseOp<?>> implements OpM
     }
 
     @Override
-    public abstract OpDispenser<T> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF);
+    public abstract OpDispenser<T> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF);
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CoreOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CoreOpMapper.java
@@ -19,7 +19,7 @@ package io.nosqlbench.adapter.cqld4.opmappers;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4BaseOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
@@ -43,6 +43,7 @@ public class Cqld4CoreOpMapper extends Cqld4BaseOpMapper<Cqld4BaseOp<?>> {
      * for it. Since the operations under the CQL driver 4.* do not follow a common type structure, we use the
      * base types in the NoSQLBench APIs and treat them somewhat more generically than with other drivers.
      *
+     * @param adapterC
      * @param op
      *     The {@link ParsedOp} which is the parsed version of the user-provided op template.
      *     This contains all the fields provided by the user, as well as explicit knowledge of
@@ -51,17 +52,17 @@ public class Cqld4CoreOpMapper extends Cqld4BaseOpMapper<Cqld4BaseOp<?>> {
      */
 
     @Override
-    public OpDispenser<Cqld4BaseOp<?>> apply(ParsedOp op, LongFunction<Cqld4Space> spaceF) {
+    public OpDispenser<Cqld4BaseOp<?>> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceF) {
         CqlD4OpType opType = CqlD4OpType.prepared;
         TypeAndTarget<CqlD4OpType, String> target = op.getTypeAndTarget(CqlD4OpType.class, String.class, "type", "stmt");
         logger.info(() -> "Using " + target.enumId + " statement form for '" + op.getName() + "'");
 
         return (OpDispenser<Cqld4BaseOp<?>>) switch (target.enumId) {
-            case raw, simple, prepared, batch -> new Cqld4CqlOpMapper(adapter).apply(op, spaceF);
-            case gremlin -> new Cqld4GremlinOpMapper(adapter, target.targetFunction).apply(op, spaceF);
-            case fluent -> new Cqld4FluentGraphOpMapper(adapter, target).apply(op, spaceF);
+            case raw, simple, prepared, batch -> new Cqld4CqlOpMapper(adapter).apply(adapterC, op, spaceF);
+            case gremlin -> new Cqld4GremlinOpMapper(adapter, target.targetFunction).apply(adapterC, op, spaceF);
+            case fluent -> new Cqld4FluentGraphOpMapper(adapter, target).apply(adapterC, op, spaceF);
             case rainbow ->
-                new CqlD4RainbowTableMapper(adapter, spaceF, target.targetFunction).apply(op, spaceF);
+                new CqlD4RainbowTableMapper(adapter, spaceF, target.targetFunction).apply(adapterC, op, spaceF);
             default -> throw new OpConfigError("Unsupported op type " + opType);
 //            case sst -> new Cqld4SsTableMapper(adapter, sessionFunc, target.targetFunction).apply(op);
         };

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlBaseOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlBaseOpMapper.java
@@ -22,8 +22,8 @@ import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
 import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -34,6 +34,6 @@ public abstract class Cqld4CqlBaseOpMapper<T extends Cqld4CqlOp> extends Cqld4Ba
     }
 
     @Override
-    public abstract OpDispenser<T> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF);
+    public abstract OpDispenser<T> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF);
 
 }

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4CqlOpMapper.java
@@ -23,6 +23,7 @@ import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlSimpleStatement;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.errors.OpConfigError;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +39,7 @@ public class Cqld4CqlOpMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlOp> {
     }
 
     @Override
-    public OpDispenser<Cqld4CqlOp> apply(ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
+    public OpDispenser<Cqld4CqlOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> spaceInitF) {
         CqlD4OpType opType = CqlD4OpType.prepared;
         TypeAndTarget<CqlD4OpType, String> target = op.getTypeAndTarget(CqlD4OpType.class, String.class, "type", "stmt");
         logger.info(() -> "Using " + target.enumId + " statement form for '" + op.getName() + "'");
@@ -46,13 +47,13 @@ public class Cqld4CqlOpMapper extends Cqld4CqlBaseOpMapper<Cqld4CqlOp> {
         return (OpDispenser<Cqld4CqlOp>) switch (target.enumId) {
             case raw -> {
                 CqlD4RawStmtMapper cqlD4RawStmtMapper = new CqlD4RawStmtMapper(adapter, target.targetFunction);
-                OpDispenser<Cqld4CqlSimpleStatement> apply = cqlD4RawStmtMapper.apply(op, spaceInitF);
+                OpDispenser<Cqld4CqlSimpleStatement> apply = cqlD4RawStmtMapper.apply(adapterC, op, spaceInitF);
                 yield apply;
             }
-            case simple -> new CqlD4CqlSimpleStmtMapper(adapter, target.targetFunction).apply(op, spaceInitF);
-            case prepared -> new CqlD4PreparedStmtMapper(adapter, target).apply(op, spaceInitF);
+            case simple -> new CqlD4CqlSimpleStmtMapper(adapter, target.targetFunction).apply(adapterC, op, spaceInitF);
+            case prepared -> new CqlD4PreparedStmtMapper(adapter, target).apply(adapterC, op, spaceInitF);
 
-            case batch -> new CqlD4BatchStmtMapper(adapter, target).apply(op, spaceInitF);
+            case batch -> new CqlD4BatchStmtMapper(adapter, target).apply(adapterC, op, spaceInitF);
             default ->
                 throw new OpConfigError("Unsupported op type for CQL category of statement forms:" + target.enumId);
         };

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4FluentGraphOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4FluentGraphOpMapper.java
@@ -27,6 +27,7 @@ import io.nosqlbench.adapter.cqld4.optypes.Cqld4FluentGraphOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.errors.OpConfigError;
 import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
@@ -58,7 +59,7 @@ public class Cqld4FluentGraphOpMapper extends Cqld4BaseOpMapper<Cqld4FluentGraph
     }
 
     @Override
-    public OpDispenser<Cqld4FluentGraphOp> apply(ParsedOp op, LongFunction<Cqld4Space> cqld4SpaceLongFunction) {
+    public OpDispenser<Cqld4FluentGraphOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<Cqld4Space> cqld4SpaceLongFunction) {
         GraphTraversalSource g = DseGraph.g;
 
         ParsedTemplateString fluent = op.getAsTemplate(target.field).orElseThrow();

--- a/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4GremlinOpMapper.java
+++ b/nb-adapters/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/opmappers/Cqld4GremlinOpMapper.java
@@ -16,17 +16,11 @@
 
 package io.nosqlbench.adapter.cqld4.opmappers;
 
-import com.datastax.oss.driver.api.core.CqlSession;
 import io.nosqlbench.adapter.cqld4.Cqld4DriverAdapter;
-import io.nosqlbench.adapter.cqld4.Cqld4Space;
 import io.nosqlbench.adapter.cqld4.opdispensers.Cqld4GremlinOpDispenser;
-import io.nosqlbench.adapter.cqld4.optypes.Cqld4CqlOp;
 import io.nosqlbench.adapter.cqld4.optypes.Cqld4ScriptGraphOp;
-import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -39,7 +33,7 @@ public class Cqld4GremlinOpMapper<CO extends Cqld4ScriptGraphOp> extends Cqld4Ba
     }
 
     @Override
-    public Cqld4GremlinOpDispenser apply(ParsedOp op, LongFunction spaceInitF) {
+    public Cqld4GremlinOpDispenser apply(NBComponent adapterC, ParsedOp op, LongFunction spaceInitF) {
         return new Cqld4GremlinOpDispenser(
             adapter,
             l -> adapter.getSpaceFunc(op).apply(l).getSession(), targetFunction, op);

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/DataApiOpMapper.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/DataApiOpMapper.java
@@ -21,9 +21,9 @@ import io.nosqlbench.adapter.dataapi.ops.DataApiBaseOp;
 import io.nosqlbench.adapter.dataapi.ops.DataApiOpType;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.util.function.LongFunction;
@@ -38,7 +38,7 @@ public class DataApiOpMapper implements OpMapper<DataApiBaseOp,DataApiSpace> {
 
 
     @Override
-    public OpDispenser<DataApiBaseOp> apply(ParsedOp op, LongFunction<DataApiSpace> spaceInitF) {
+    public OpDispenser<DataApiBaseOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<DataApiSpace> spaceInitF) {
     //public OpDispenser<DataApiBaseOp> apply(ParsedOp op, LongFunction<DataApiSpace> spaceInitF) {
         TypeAndTarget<DataApiOpType, String> typeAndTarget = op.getTypeAndTarget(
             DataApiOpType.class,

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCountDocumentsOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCountDocumentsOpDispenser.java
@@ -52,7 +52,7 @@ public class DataApiCountDocumentsOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateCollectionOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateCollectionOpDispenser.java
@@ -51,8 +51,8 @@ public class DataApiCreateCollectionOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 
 

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateCollectionWithClassOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateCollectionWithClassOpDispenser.java
@@ -53,8 +53,8 @@ public class DataApiCreateCollectionWithClassOpDispenser extends DataApiOpDispen
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 
 

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateDatabaseOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateDatabaseOpDispenser.java
@@ -61,7 +61,7 @@ public class DataApiCreateDatabaseOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateNamespaceOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiCreateNamespaceOpDispenser.java
@@ -43,7 +43,7 @@ public class DataApiCreateNamespaceOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteAllOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteAllOpDispenser.java
@@ -47,7 +47,7 @@ public class DataApiDeleteAllOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteManyOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteManyOpDispenser.java
@@ -50,7 +50,7 @@ public class DataApiDeleteManyOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDeleteOneOpDispenser.java
@@ -73,7 +73,7 @@ public class DataApiDeleteOneOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropCollectionOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropCollectionOpDispenser.java
@@ -41,7 +41,7 @@ public class DataApiDropCollectionOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropDatabaseOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropDatabaseOpDispenser.java
@@ -43,7 +43,7 @@ public class DataApiDropDatabaseOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropNamespaceOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiDropNamespaceOpDispenser.java
@@ -44,7 +44,7 @@ public class DataApiDropNamespaceOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiEstimatedDocumentCountOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiEstimatedDocumentCountOpDispenser.java
@@ -41,7 +41,7 @@ public class DataApiEstimatedDocumentCountOpDispenser extends DataApiOpDispenser
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindByIdOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindByIdOpDispenser.java
@@ -56,7 +56,7 @@ public class DataApiFindByIdOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindDistinctOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindDistinctOpDispenser.java
@@ -61,7 +61,7 @@ public class DataApiFindDistinctOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndDeleteOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndDeleteOpDispenser.java
@@ -68,7 +68,7 @@ public class DataApiFindOneAndDeleteOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndReplaceOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndReplaceOpDispenser.java
@@ -86,7 +86,7 @@ public class DataApiFindOneAndReplaceOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndUpdateOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneAndUpdateOpDispenser.java
@@ -52,7 +52,7 @@ public class DataApiFindOneAndUpdateOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOneOpDispenser.java
@@ -70,7 +70,7 @@ public class DataApiFindOneOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindOpDispenser.java
@@ -88,7 +88,7 @@ public class DataApiFindOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindVectorFilterOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindVectorFilterOpDispenser.java
@@ -56,7 +56,7 @@ public class DataApiFindVectorFilterOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindVectorOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiFindVectorOpDispenser.java
@@ -56,7 +56,7 @@ public class DataApiFindVectorOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiGetDatabaseInfoOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiGetDatabaseInfoOpDispenser.java
@@ -44,7 +44,7 @@ public class DataApiGetDatabaseInfoOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertManyOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertManyOpDispenser.java
@@ -75,7 +75,7 @@ public class DataApiInsertManyOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertOneOpDispenser.java
@@ -49,7 +49,7 @@ public class DataApiInsertOneOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertOneVectorOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiInsertOneVectorOpDispenser.java
@@ -52,7 +52,7 @@ public class DataApiInsertOneVectorOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListCollectionNamesOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListCollectionNamesOpDispenser.java
@@ -37,7 +37,7 @@ public class DataApiListCollectionNamesOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListCollectionsOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListCollectionsOpDispenser.java
@@ -40,7 +40,7 @@ public class DataApiListCollectionsOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListDatabasesOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListDatabasesOpDispenser.java
@@ -41,7 +41,7 @@ public class DataApiListDatabasesOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListNamespacesOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiListNamespacesOpDispenser.java
@@ -42,7 +42,7 @@ public class DataApiListNamespacesOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiOpDispenser.java
@@ -32,7 +32,7 @@ public abstract class DataApiOpDispenser extends BaseOpDispenser<DataApiBaseOp, 
 
     protected DataApiOpDispenser(DriverAdapter<? extends DataApiBaseOp, DataApiSpace> adapter, ParsedOp op,
                                  LongFunction<String> targetFunction) {
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         this.targetFunction = targetFunction;
         this.spaceFunction = adapter.getSpaceFunc(op);
     }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiReplaceOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiReplaceOneOpDispenser.java
@@ -68,7 +68,7 @@ public class DataApiReplaceOneOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiUpdateManyOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiUpdateManyOpDispenser.java
@@ -66,7 +66,7 @@ public class DataApiUpdateManyOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiUpdateOneOpDispenser.java
+++ b/nb-adapters/adapter-dataapi/src/main/java/io/nosqlbench/adapter/dataapi/opdispensers/DataApiUpdateOneOpDispenser.java
@@ -75,7 +75,7 @@ public class DataApiUpdateOneOpDispenser extends DataApiOpDispenser {
     }
 
     @Override
-    public DataApiBaseOp getOp(long value) {
-        return opFunction.apply(value);
+    public DataApiBaseOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-diag/src/main/java/io/nosqlbench/adapter/diag/DiagOpDispenser.java
+++ b/nb-adapters/adapter-diag/src/main/java/io/nosqlbench/adapter/diag/DiagOpDispenser.java
@@ -40,7 +40,7 @@ public class DiagOpDispenser extends BaseOpDispenser<DiagOp,DiagSpace> implement
     private OpFunc opFuncs;
 
     public DiagOpDispenser(DiagDriverAdapter adapter, LongFunction<DiagSpace> spaceF, ParsedOp op) {
-        super(adapter,op);
+        super(adapter,op, adapter.getSpaceFunc(op));
         this.opFunc = resolveOpFunc(spaceF, op);
     }
 
@@ -129,7 +129,7 @@ public class DiagOpDispenser extends BaseOpDispenser<DiagOp,DiagSpace> implement
     }
 
     @Override
-    public DiagOp getOp(long value) {
-        return opFunc.apply(value);
+    public DiagOp getOp(long cycle) {
+        return opFunc.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-diag/src/main/java/io/nosqlbench/adapter/diag/DiagOpMapper.java
+++ b/nb-adapters/adapter-diag/src/main/java/io/nosqlbench/adapter/diag/DiagOpMapper.java
@@ -18,8 +18,8 @@ package io.nosqlbench.adapter.diag;
 
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfigModel;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.nb.api.config.standard.NBReconfigurable;
@@ -38,7 +38,7 @@ public class DiagOpMapper implements OpMapper<DiagOp,DiagSpace>, NBReconfigurabl
     }
 
     @Override
-    public OpDispenser<DiagOp> apply(ParsedOp op, LongFunction<DiagSpace> spaceInitF) {
+    public OpDispenser<DiagOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<DiagSpace> spaceInitF) {
         LongFunction<DiagSpace> spaceF = adapter.getSpaceFunc(op);
         DiagOpDispenser dispenser = new DiagOpDispenser(adapter,spaceF,op);
         dispensers.put(op.getName(),dispenser);

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBOpMapper.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/DynamoDBOpMapper.java
@@ -21,11 +21,10 @@ import io.nosqlbench.adapter.dynamodb.opdispensers.*;
 import io.nosqlbench.adapter.dynamodb.optypes.DynamoDBOp;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
 import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 
 import java.util.function.LongFunction;
@@ -41,7 +40,7 @@ public class DynamoDBOpMapper implements OpMapper<DynamoDBOp,DynamoDBSpace> {
     }
 
     @Override
-    public OpDispenser<DynamoDBOp> apply(ParsedOp op, LongFunction<DynamoDBSpace> spaceInitF) {
+    public OpDispenser<DynamoDBOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<DynamoDBSpace> spaceInitF) {
         int space = op.getStaticConfigOr("space", 0);
         LongFunction<DynamoDBSpace> spaceFunc = adapter.getSpaceFunc(op);
         DynamoDB ddb = spaceFunc.apply(space).getDynamoDB();

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBCreateTableOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBCreateTableOpDispenser.java
@@ -117,7 +117,7 @@ public class DDBCreateTableOpDispenser extends BaseOpDispenser<DynamoDBOp, Dynam
     private final LongFunction<String> billingModeFunc;
 
     public DDBCreateTableOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp cmd, LongFunction<?> targetFunc) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.ddb = ddb;
         this.tableNameFunc = l -> targetFunc.apply(l).toString();
         this.keySchemaFunc = resolveKeySchemaFunction(cmd);

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBDeleteTableOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBDeleteTableOpDispenser.java
@@ -41,7 +41,7 @@ public class DDBDeleteTableOpDispenser extends BaseOpDispenser<DynamoDBOp, Dynam
     private final LongFunction<String> tableNameFunc;
 
     public DDBDeleteTableOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp cmd, LongFunction<?> targetFunc) {
-        super(adapter, cmd);
+        super(adapter, cmd, adapter.getSpaceFunc(cmd));
         this.ddb = ddb;
         this.tableNameFunc = l -> targetFunc.apply(l).toString();
     }

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBGetItemOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBGetItemOpDispenser.java
@@ -37,7 +37,7 @@ public class DDBGetItemOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDBS
     private final LongFunction<GetItemSpec> getItemSpecFunc;
 
     public DDBGetItemOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp cmd, LongFunction<?> targetFunction) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.ddb = ddb;
         this.targetTableFunction = l -> ddb.getTable(targetFunction.apply(l).toString());
         this.getItemSpecFunc = resolveGetItemSpecFunction(cmd);
@@ -83,9 +83,9 @@ public class DDBGetItemOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDBS
     }
 
     @Override
-    public DDBGetItemOp getOp(long value) {
-        Table table = targetTableFunction.apply(value);
-        GetItemSpec getitemSpec = getItemSpecFunc.apply(value);
+    public DDBGetItemOp getOp(long cycle) {
+        Table table = targetTableFunction.apply(cycle);
+        GetItemSpec getitemSpec = getItemSpecFunc.apply(cycle);
         return new DDBGetItemOp(ddb, table, getitemSpec);
     }
 }

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBPutItemOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBPutItemOpDispenser.java
@@ -36,7 +36,7 @@ public class DDBPutItemOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDBS
     private final LongFunction<? extends Item> itemfunc;
 
     public DDBPutItemOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp cmd, LongFunction<?> targetFunc) {
-        super(adapter, cmd);
+        super(adapter, cmd, adapter.getSpaceFunc(cmd));
         this.ddb = ddb;
         this.tableNameFunc = l -> targetFunc.apply(l).toString();
         if (cmd.isDefined("item")) {
@@ -51,9 +51,9 @@ public class DDBPutItemOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDBS
     }
 
     @Override
-    public DynamoDBOp getOp(long value) {
-        String tablename = tableNameFunc.apply(value);
-        Item item = itemfunc.apply(value);
+    public DynamoDBOp getOp(long cycle) {
+        String tablename = tableNameFunc.apply(cycle);
+        Item item = itemfunc.apply(cycle);
         return new DDBPutItemOp(ddb,tablename,item);
     }
 }

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBQueryOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/DDBQueryOpDispenser.java
@@ -141,7 +141,7 @@ public class DDBQueryOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDBSpa
     private final LongFunction<QuerySpec> querySpecFunc;
 
     public DDBQueryOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp cmd, LongFunction<?> targetFunc) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.ddb = ddb;
         LongFunction<String> tableNameFunc = l -> targetFunc.apply(l).toString();
         this.tableFunc = l -> ddb.getTable(tableNameFunc.apply(l));

--- a/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/RawDynamoDBOpDispenser.java
+++ b/nb-adapters/adapter-dynamodb/src/main/java/io/nosqlbench/adapter/dynamodb/opdispensers/RawDynamoDBOpDispenser.java
@@ -32,7 +32,7 @@ public class RawDynamoDBOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDB
     private final DynamoDB ddb;
 
     public RawDynamoDBOpDispenser(DriverAdapter adapter, DynamoDB ddb, ParsedOp pop) {
-        super(adapter,pop);
+        super(adapter,pop, adapter.getSpaceFunc(pop));
         this.ddb = ddb;
 
         String bodytype = pop.getValueType("body").getSimpleName();
@@ -44,8 +44,8 @@ public class RawDynamoDBOpDispenser extends BaseOpDispenser<DynamoDBOp, DynamoDB
     }
 
     @Override
-    public DynamoDBOp getOp(long value) {
-        String body = jsonFunction.apply(value);
+    public DynamoDBOp getOp(long cycle) {
+        String body = jsonFunction.apply(cycle);
         return new RawDynamodOp(ddb,body);
     }
 }

--- a/nb-adapters/adapter-example/pom.xml
+++ b/nb-adapters/adapter-example/pom.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Copyright (c) 2022-2023 nosqlbench
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>mvn-defaults</artifactId>
+        <groupId>io.nosqlbench</groupId>
+        <version>${revision}</version>
+        <relativePath>../../mvn-defaults</relativePath>
+    </parent>
+
+    <artifactId>adapter-example</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+
+    <description>
+        A HTTP nosqlbench DriverAdapter driver module;
+        This module provides a basic starting point for a fully featured adapter.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.nosqlbench</groupId>
+            <artifactId>adapters-api</artifactId>
+            <version>${revision}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapter.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapter.java
@@ -2,13 +2,13 @@ package io.nosqlbench.adapter.prototype;
 
 /*
  * Copyright (c) nosqlbench
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,9 +21,12 @@ package io.nosqlbench.adapter.prototype;
 import io.nosqlbench.adapter.prototype.ops.ExampleOpType1;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
 import io.nosqlbench.adapters.api.activityimpl.uniform.BaseDriverAdapter;
+import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
+import io.nosqlbench.nb.annotations.Service;
 import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.labels.NBLabels;
 
+@Service(value = DriverAdapter.class, selector = "example")
 public class ExampleDriverAdapter extends BaseDriverAdapter<ExampleOpType1, ExampleSpace> {
 
     public ExampleDriverAdapter(NBComponent parentComponent, NBLabels labels) {

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapter.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapter.java
@@ -1,0 +1,37 @@
+package io.nosqlbench.adapter.prototype;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.ops.ExampleOpType1;
+import io.nosqlbench.adapters.api.activityimpl.OpMapper;
+import io.nosqlbench.adapters.api.activityimpl.uniform.BaseDriverAdapter;
+import io.nosqlbench.nb.api.components.core.NBComponent;
+import io.nosqlbench.nb.api.labels.NBLabels;
+
+public class ExampleDriverAdapter extends BaseDriverAdapter<ExampleOpType1, ExampleSpace> {
+
+    public ExampleDriverAdapter(NBComponent parentComponent, NBLabels labels) {
+        super(parentComponent, labels);
+    }
+
+    @Override
+    public OpMapper<ExampleOpType1, ExampleSpace> getOpMapper() {
+        return new ExampleOpMapper();
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapterLoader.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleDriverAdapterLoader.java
@@ -1,0 +1,36 @@
+package io.nosqlbench.adapter.prototype;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.diag.DriverAdapterLoader;
+import io.nosqlbench.nb.annotations.Service;
+import io.nosqlbench.nb.api.components.core.NBComponent;
+import io.nosqlbench.nb.api.labels.NBLabels;
+
+@Service(value = DriverAdapterLoader.class, selector = "example")
+public class ExampleDriverAdapterLoader implements DriverAdapterLoader {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ExampleDriverAdapter load(NBComponent parent, NBLabels childLabels) {
+        return new ExampleDriverAdapter(parent, childLabels);
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleOpMapper.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleOpMapper.java
@@ -1,0 +1,48 @@
+package io.nosqlbench.adapter.prototype;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.dispensers.ExampleOpDispenserType1;
+import io.nosqlbench.adapter.prototype.ops.ExampleOpType1;
+import io.nosqlbench.adapter.prototype.ops.ExampleOpTypes;
+import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
+import io.nosqlbench.adapters.api.activityimpl.OpMapper;
+import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
+
+import java.util.function.LongFunction;
+
+public class ExampleOpMapper implements OpMapper<ExampleOpType1, ExampleSpace> {
+
+    @Override
+    public OpDispenser<ExampleOpType1> apply(
+        NBComponent adapterC,
+        ParsedOp pop,
+        LongFunction<ExampleSpace> spaceInitF
+    ) {
+        TypeAndTarget<ExampleOpTypes, String> typeAndTarget = pop.getTypeAndTarget(ExampleOpTypes.class, String.class);
+
+        return switch (typeAndTarget.enumId) {
+            case type1 -> new ExampleOpDispenserType1(adapterC, pop, spaceInitF);
+            case type2 -> new ExampleOpDispenserType1(adapterC, pop, spaceInitF);
+        };
+
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleSpace.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ExampleSpace.java
@@ -1,0 +1,30 @@
+package io.nosqlbench.adapter.prototype;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapters.api.activityimpl.uniform.BaseSpace;
+import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
+
+public class ExampleSpace extends BaseSpace<ExampleSpace> {
+
+    public ExampleSpace(DriverAdapter<?, ExampleSpace> adapter, long idx) {
+        super(adapter, idx);
+    }
+
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/dispensers/ExampleOpDispenserType1.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/dispensers/ExampleOpDispenserType1.java
@@ -1,0 +1,43 @@
+package io.nosqlbench.adapter.prototype.dispensers;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.ExampleSpace;
+import io.nosqlbench.adapter.prototype.ops.ExampleOpType1;
+import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
+import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
+
+import java.util.function.LongFunction;
+
+public class ExampleOpDispenserType1 extends BaseOpDispenser<ExampleOpType1, ExampleSpace> {
+
+    public ExampleOpDispenserType1(
+        NBComponent adapter,
+        ParsedOp pop,
+        LongFunction<ExampleSpace> spaceInitF
+    ) {
+        super(adapter, pop, spaceInitF);
+    }
+
+    @Override
+    public ExampleOpType1 getOp(long cycle) {
+        return new ExampleOpType1(cycle);
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/dispensers/ExampleOpDispenserType2.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/dispensers/ExampleOpDispenserType2.java
@@ -1,0 +1,43 @@
+package io.nosqlbench.adapter.prototype.dispensers;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.ExampleSpace;
+import io.nosqlbench.adapter.prototype.ops.ExampleOpType2;
+import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
+import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
+
+import java.util.function.LongFunction;
+
+public class ExampleOpDispenserType2 extends BaseOpDispenser<ExampleOpType2, ExampleSpace> {
+
+    public ExampleOpDispenserType2(
+        NBComponent adapter,
+        ParsedOp pop,
+        LongFunction<ExampleSpace> spaceInitF
+    ) {
+        super(adapter, pop, spaceInitF);
+    }
+
+    @Override
+    public ExampleOpType2 getOp(long cycle) {
+        return new ExampleOpType2();
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpType1.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpType1.java
@@ -1,0 +1,39 @@
+package io.nosqlbench.adapter.prototype.ops;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.results.ExampleStringResult;
+import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ExampleOpType1 implements CycleOp<ExampleStringResult> {
+
+    private final static Logger logger = LogManager.getLogger(ExampleOpType1.class);
+    private final long cycle;
+
+    public ExampleOpType1(long cycle) {
+        this.cycle = cycle;
+    }
+
+    @Override
+    public ExampleStringResult apply(long value) {
+        return new ExampleStringResult("ProtoOpType1 cycle(" + value + ")");
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpType2.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpType2.java
@@ -1,0 +1,34 @@
+package io.nosqlbench.adapter.prototype.ops;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.nosqlbench.adapter.prototype.results.ExampleStringResult;
+import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ExampleOpType2 implements CycleOp<ExampleStringResult> {
+
+    private final static Logger logger = LogManager.getLogger(ExampleOpType2.class);
+
+    @Override
+    public ExampleStringResult apply(long value) {
+        return new ExampleStringResult("ProtoOpType1 cycle(" + value + ")");
+    }
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpTypes.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/ops/ExampleOpTypes.java
@@ -1,0 +1,24 @@
+package io.nosqlbench.adapter.prototype.ops;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public enum ExampleOpTypes {
+    type1,
+    type2
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/package-info.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * This package contains an example implementation of a
+ * {@link io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter}.
+ * It is meant to demonstrate common implementation patterns as a starting point for new driver adapters.
+ * For a given adapter implementation, only some of these patterns will be needed, but examples aim to cover
+ * also some of the non-trivial patterns needed to implement advanced logic.
+ */
+package io.nosqlbench.adapter.prototype;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/results/ExampleResult.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/results/ExampleResult.java
@@ -1,0 +1,26 @@
+package io.nosqlbench.adapter.prototype.results;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * Each {@link io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter} implementation
+ * is generic over a type of
+ */
+public interface ExampleResult {
+}

--- a/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/results/ExampleStringResult.java
+++ b/nb-adapters/adapter-example/src/main/java/io/nosqlbench/adapter/prototype/results/ExampleStringResult.java
@@ -1,0 +1,30 @@
+package io.nosqlbench.adapter.prototype.results;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public class ExampleStringResult implements ExampleResult {
+    private final String message;
+    public ExampleStringResult(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/GCPSpannerOpMapper.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/GCPSpannerOpMapper.java
@@ -21,13 +21,12 @@ import io.nosqlbench.adapter.gcpspanner.ops.GCPSpannerBaseOp;
 import io.nosqlbench.adapter.gcpspanner.types.GCPSpannerOpType;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public class GCPSpannerOpMapper implements OpMapper<GCPSpannerBaseOp<?,?>, GCPSpannerSpace> {
@@ -49,6 +48,7 @@ public class GCPSpannerOpMapper implements OpMapper<GCPSpannerBaseOp<?,?>, GCPSp
      * Given an instance of a {@link ParsedOp} returns the appropriate
      * {@link GCPSpannerBaseOpDispenser} subclass.
      *
+     * @param adapterC
      * @param op
      *     The {@link ParsedOp} to be evaluated
      * @param spaceInitF
@@ -56,7 +56,7 @@ public class GCPSpannerOpMapper implements OpMapper<GCPSpannerBaseOp<?,?>, GCPSp
      *     the op type
      */
     @Override
-    public OpDispenser<GCPSpannerBaseOp<?,?>> apply(ParsedOp op, LongFunction<GCPSpannerSpace> spaceInitF) {
+    public OpDispenser<GCPSpannerBaseOp<?,?>> apply(NBComponent adapterC, ParsedOp op, LongFunction<GCPSpannerSpace> spaceInitF) {
         TypeAndTarget<GCPSpannerOpType, String> typeAndTarget = op.getTypeAndTarget(GCPSpannerOpType.class,
             String.class, "type", "target");
         logger.info(() -> "Using '" + typeAndTarget.enumId + "' op type for op template '" + op.getName() + "'");

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerBaseOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerBaseOpDispenser.java
@@ -21,7 +21,6 @@ import io.nosqlbench.adapter.gcpspanner.GCPSpannerDriverAdapter;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
 import io.nosqlbench.adapter.gcpspanner.ops.GCPSpannerBaseOp;
 import io.nosqlbench.adapter.gcpspanner.GCPSpannerSpace;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 
 import java.util.function.LongFunction;
@@ -52,7 +51,7 @@ public abstract class GCPSpannerBaseOpDispenser<OP extends GCPSpannerBaseOp,RESU
      */
     protected GCPSpannerBaseOpDispenser(GCPSpannerDriverAdapter adapter, ParsedOp op,
                                         LongFunction<String> targetFunction) {
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         this.targetFunction = targetFunction;
         this.spaceFunction = adapter.getSpaceFunc(op);
     }

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerCreateDatabaseDdlOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerCreateDatabaseDdlOpDispenser.java
@@ -78,12 +78,12 @@ public class GCPSpannerCreateDatabaseDdlOpDispenser
     /**
      * Retrieves an operation instance based on the provided value.
      *
-     * @param value
+     * @param cycle
      *     the long value used to generate the operation
      * @return a {@link GCPSpannerBaseOp} instance
      */
     @Override
-    public GCPSpannerCreateDatabaseDdlOp getOp(long value) {
-        return opFunction.apply(value);
+    public GCPSpannerCreateDatabaseDdlOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerDropDatabaseDdlOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerDropDatabaseDdlOpDispenser.java
@@ -83,11 +83,11 @@ public class GCPSpannerDropDatabaseDdlOpDispenser extends GCPSpannerBaseOpDispen
     /**
      * Retrieves an operation instance based on the provided value.
      *
-     * @param value the long value used to generate the operation
+     * @param cycle the long value used to generate the operation
      * @return a {@link GCPSpannerBaseOp} instance
      */
     @Override
-    public GCPSpannerDropDatabaseDdlOp getOp(long value) {
-        return opFunction.apply(value);
+    public GCPSpannerDropDatabaseDdlOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerExecuteDmlOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerExecuteDmlOpDispenser.java
@@ -77,11 +77,11 @@ public class GCPSpannerExecuteDmlOpDispenser extends GCPSpannerBaseOpDispenser<G
     /**
      * Retrieves the GCP Spanner operation for the given value.
      *
-     * @param value the input value
+     * @param cycle the input value
      * @return the GCP Spanner operation
      */
     @Override
-    public GCPSpannerExecuteDmlOp getOp(long value) {
-        return opFunction.apply(value);
+    public GCPSpannerExecuteDmlOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerInsertOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerInsertOpDispenser.java
@@ -66,21 +66,21 @@ public class GCPSpannerInsertOpDispenser extends GCPSpannerBaseOpDispenser<GCPSp
     /**
      * Returns a GCPSpannerInsertVectorOp instance configured with the provided value.
      *
-     * @param value the value used to configure the operation
+     * @param cycle the value used to configure the operation
      * @return a configured GCPSpannerInsertVectorOp instance
      */
     @Override
-    public GCPSpannerInsertOp getOp(long value) {
-        Mutation.WriteBuilder builder = Mutation.newInsertBuilder(targetFunction.apply(value));
-        Map<String, Object> params = queryParamsFunction.apply(value);
+    public GCPSpannerInsertOp getOp(long cycle) {
+        Mutation.WriteBuilder builder = Mutation.newInsertBuilder(targetFunction.apply(cycle));
+        Map<String, Object> params = queryParamsFunction.apply(cycle);
         for (Map.Entry<String, Object> entry : params.entrySet()) {
             builder.set(entry.getKey()).to(convertToValue(entry));
         }
         return new GCPSpannerInsertOp(
-            spaceFunction.apply(value).getSpanner(),
-            value,
+            spaceFunction.apply(cycle).getSpanner(),
+                cycle,
             builder.build(),
-            spaceFunction.apply(value).getDbClient()
+            spaceFunction.apply(cycle).getDbClient()
         );
     }
 

--- a/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerUpdateDatabaseDdlOpDispenser.java
+++ b/nb-adapters/adapter-gcp-spanner/src/main/java/io/nosqlbench/adapter/gcpspanner/opdispensers/GCPSpannerUpdateDatabaseDdlOpDispenser.java
@@ -66,11 +66,11 @@ public class GCPSpannerUpdateDatabaseDdlOpDispenser
     /**
      * Retrieves an operation instance based on the provided value.
      *
-     * @param value the long value used to generate the operation
+     * @param cycle the long value used to generate the operation
      * @return a GCPSpannerBaseOp instance
      */
     @Override
-    public GCPSpannerUpdateDatabaseDdlOp getOp(long value) {
-        return opFunction.apply(value);
+    public GCPSpannerUpdateDatabaseDdlOp getOp(long cycle) {
+        return opFunction.apply(cycle);
     }
 }

--- a/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpDispenser.java
+++ b/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpDispenser.java
@@ -37,7 +37,7 @@ public class HttpOpDispenser extends BaseOpDispenser<HttpOp, HttpSpace> {
 
 
     public HttpOpDispenser(DriverAdapter adapter, LongFunction<HttpSpace> ctxF, ParsedOp op) {
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         opFunc = getOpFunc(ctxF, op);
     }
 
@@ -128,8 +128,8 @@ public class HttpOpDispenser extends BaseOpDispenser<HttpOp, HttpSpace> {
     }
 
     @Override
-    public HttpOp getOp(long value) {
-        HttpOp op = this.opFunc.apply(value);
+    public HttpOp getOp(long cycle) {
+        HttpOp op = this.opFunc.apply(cycle);
         return op;
 
     }

--- a/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpMapper.java
+++ b/nb-adapters/adapter-http/src/main/java/io/nosqlbench/adapter/http/core/HttpOpMapper.java
@@ -19,10 +19,9 @@ package io.nosqlbench.adapter.http.core;
 import io.nosqlbench.adapter.http.HttpDriverAdapter;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
 import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 
 import java.util.function.LongFunction;
@@ -38,7 +37,7 @@ public class HttpOpMapper implements OpMapper<HttpOp,HttpSpace> {
     }
 
     @Override
-    public OpDispenser<HttpOp> apply(ParsedOp op, LongFunction<HttpSpace> spaceInitF) {
+    public OpDispenser<HttpOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<HttpSpace> spaceInitF) {
         LongFunction<String> spaceNameF = op.getAsFunctionOr("space", "default");
         return new HttpOpDispenser(adapter, spaceInitF, op);
     }

--- a/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaOpMapper.java
+++ b/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/KafkaOpMapper.java
@@ -19,8 +19,7 @@ package io.nosqlbench.adapter.kafka;
 import io.nosqlbench.adapter.kafka.dispensers.MessageConsumerOpDispenser;
 import io.nosqlbench.adapter.kafka.dispensers.MessageProducerOpDispenser;
 import io.nosqlbench.adapter.kafka.ops.KafkaOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
@@ -29,7 +28,7 @@ import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import java.util.function.IntFunction;
+
 import java.util.function.LongFunction;
 
 public class KafkaOpMapper implements OpMapper<KafkaOp,KafkaSpace> {
@@ -43,7 +42,7 @@ public class KafkaOpMapper implements OpMapper<KafkaOp,KafkaSpace> {
     }
 
     @Override
-    public OpDispenser<KafkaOp> apply(ParsedOp op, LongFunction<KafkaSpace> spaceInitF) {
+    public OpDispenser<KafkaOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<KafkaSpace> spaceInitF) {
         KafkaSpace kafkaSpace = adapter.getSpaceFunc(op).apply(op.getStaticConfigOr("space",0));
 
         /*

--- a/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
+++ b/nb-adapters/adapter-kafka/src/main/java/io/nosqlbench/adapter/kafka/dispensers/KafkaBaseOpDispenser.java
@@ -62,7 +62,7 @@ public abstract  class KafkaBaseOpDispenser extends BaseOpDispenser<KafkaOp, Kaf
                                    final LongFunction<String> topicNameStrFunc,
                                    final KafkaSpace kafkaSpace) {
 
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
 
         parsedOp = op;
         this.kafkaSpace = kafkaSpace;

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoOpMapper.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/core/MongoOpMapper.java
@@ -18,7 +18,7 @@ package io.nosqlbench.adapter.mongodb.core;
 
 import io.nosqlbench.adapter.mongodb.dispensers.MongoCommandOpDispenser;
 import io.nosqlbench.adapter.mongodb.ops.MongoDirectCommandOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.nb.api.errors.BasicError;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
@@ -43,7 +43,7 @@ public class MongoOpMapper<MC extends MongoDirectCommandOp> implements OpMapper<
     }
 
     @Override
-    public OpDispenser<MongoDirectCommandOp> apply(ParsedOp op, LongFunction<MongoSpace> spaceInitF) {
+    public OpDispenser<MongoDirectCommandOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<MongoSpace> spaceInitF) {
 
         LongFunction<String> ctxNamer = op.getAsFunctionOr("space", "default");
 

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/dispensers/MongoCommandOpDispenser.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/dispensers/MongoCommandOpDispenser.java
@@ -35,7 +35,7 @@ public class MongoCommandOpDispenser extends BaseOpDispenser<MongoDirectCommandO
         DriverAdapter adapter, LongFunction<MongoSpace> ctxFunc,
         ParsedOp op
     ) {
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         this.mongoOpF = createOpFunc(ctxFunc, op);
     }
 

--- a/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/dispensers/MongoDbUpdateOpDispenser.java
+++ b/nb-adapters/adapter-mongodb/src/main/java/io/nosqlbench/adapter/mongodb/dispensers/MongoDbUpdateOpDispenser.java
@@ -20,14 +20,11 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import io.nosqlbench.adapter.mongodb.core.MongoSpace;
 import io.nosqlbench.adapter.mongodb.core.MongodbDriverAdapter;
-import io.nosqlbench.adapter.mongodb.ops.MongoDbUpdateOp;
 import io.nosqlbench.adapter.mongodb.ops.MongoDirectCommandOp;
 import io.nosqlbench.adapter.mongodb.ops.MongoOp;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import org.bson.BsonDocument;
-import org.bson.conversions.Bson;
 
 import java.util.function.LongFunction;
 
@@ -41,7 +38,7 @@ public class MongoDbUpdateOpDispenser extends BaseOpDispenser<MongoOp<?>, MongoS
     private final LongFunction<String> collectionF;
 
     public MongoDbUpdateOpDispenser(MongodbDriverAdapter adapter, ParsedOp pop, LongFunction<String> collectionF) {
-        super(adapter, pop);
+        super(adapter, pop, adapter.getSpaceFunc(pop));
         this.collectionF = collectionF;
         this.spaceF = adapter.getSpaceFunc(pop);
         this.opF = createOpF(pop);
@@ -55,8 +52,8 @@ public class MongoDbUpdateOpDispenser extends BaseOpDispenser<MongoOp<?>, MongoS
     }
 
     @Override
-    public MongoOp<?> getOp(long value) {
-        MongoOp<?> op = opF.apply(value);
+    public MongoOp<?> getOp(long cycle) {
+        MongoOp<?> op = opF.apply(cycle);
         return op;
     }
 

--- a/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JOpMapper.java
+++ b/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/Neo4JOpMapper.java
@@ -21,12 +21,10 @@ import io.nosqlbench.adapter.neo4j.ops.Neo4JBaseOp;
 import io.nosqlbench.adapter.neo4j.types.Neo4JOpType;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 
@@ -38,7 +36,7 @@ public class Neo4JOpMapper implements OpMapper<Neo4JBaseOp,Neo4JSpace> {
     }
 
     @Override
-    public OpDispenser<Neo4JBaseOp> apply(ParsedOp op, LongFunction<Neo4JSpace> spaceInitF) {
+    public OpDispenser<Neo4JBaseOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<Neo4JSpace> spaceInitF) {
         TypeAndTarget<Neo4JOpType, String> typeAndTarget = op.getTypeAndTarget(Neo4JOpType.class, String.class);
         LongFunction<Neo4JSpace> spaceFunc = adapter.getSpaceFunc(op);
         return switch (typeAndTarget.enumId) {

--- a/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/opdispensers/Neo4JBaseOpDispenser.java
+++ b/nb-adapters/adapter-neo4j/src/main/java/io/nosqlbench/adapter/neo4j/opdispensers/Neo4JBaseOpDispenser.java
@@ -42,7 +42,7 @@ public abstract class Neo4JBaseOpDispenser extends BaseOpDispenser<Neo4JBaseOp, 
     protected final LongFunction<AsyncSession> asyncSessionFunc;
 
     public Neo4JBaseOpDispenser(Neo4JDriverAdapter adapter, ParsedOp op, LongFunction<Neo4JSpace> spaceFunc, String requiredTemplateKey) {
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
         this.spaceFunc = spaceFunc;
         this.cypherFunc = op.getAsRequiredFunction(requiredTemplateKey);
         this.paramFunc = createParamFunc(op);

--- a/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarOpMapper.java
+++ b/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/PulsarOpMapper.java
@@ -18,18 +18,15 @@ package io.nosqlbench.adapter.pulsar;
 
 import io.nosqlbench.adapter.pulsar.dispensers.*;
 import io.nosqlbench.adapter.pulsar.ops.PulsarOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.nb.api.config.standard.NBConfiguration;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public class PulsarOpMapper implements OpMapper<PulsarOp,PulsarSpace> {
@@ -45,7 +42,7 @@ public class PulsarOpMapper implements OpMapper<PulsarOp,PulsarSpace> {
     }
 
     @Override
-    public OpDispenser<PulsarOp> apply(ParsedOp op, LongFunction<PulsarSpace> spaceInitF) {
+    public OpDispenser<PulsarOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<PulsarSpace> spaceInitF) {
         int spaceName = op.getStaticConfigOr("space", 0);
 //        PulsarSpace pulsarSpace = spaceCache.get(spaceName);
         PulsarSpace pulsarSpace = adapter.getSpaceFunc(op).apply(spaceName);

--- a/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/PulsarBaseOpDispenser.java
+++ b/nb-adapters/adapter-pulsar/src/main/java/io/nosqlbench/adapter/pulsar/dispensers/PulsarBaseOpDispenser.java
@@ -68,7 +68,7 @@ public abstract class PulsarBaseOpDispenser extends BaseOpDispenser<PulsarOp, Pu
                                     final LongFunction<String> tgtNameFunc,
                                     final PulsarSpace pulsarSpace) {
 
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
 
         parsedOp = op;
         this.tgtNameFunc = tgtNameFunc;

--- a/nb-adapters/adapter-qdrant/src/main/java/io/nosqlbench/adapter/qdrant/QdrantOpMapper.java
+++ b/nb-adapters/adapter-qdrant/src/main/java/io/nosqlbench/adapter/qdrant/QdrantOpMapper.java
@@ -21,13 +21,12 @@ import io.nosqlbench.adapter.qdrant.ops.QdrantBaseOp;
 import io.nosqlbench.adapter.qdrant.types.QdrantOpType;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public class QdrantOpMapper implements OpMapper<QdrantBaseOp<?,?>,QdrantSpace> {
@@ -46,13 +45,14 @@ public class QdrantOpMapper implements OpMapper<QdrantBaseOp<?,?>,QdrantSpace> {
     /**
      * Given an instance of a {@link ParsedOp} returns the appropriate {@link QdrantBaseOpDispenser} subclass
      *
+     * @param adapterC
      * @param op
-     *         The {@link ParsedOp} to be evaluated
+     *     The {@link ParsedOp} to be evaluated
      * @param spaceInitF
      * @return The correct {@link QdrantBaseOpDispenser} subclass based on the op type
      */
     @Override
-    public OpDispenser<QdrantBaseOp<?,?>> apply(ParsedOp op, LongFunction<QdrantSpace> spaceInitF) {
+    public OpDispenser<QdrantBaseOp<?,?>> apply(NBComponent adapterC, ParsedOp op, LongFunction<QdrantSpace> spaceInitF) {
         TypeAndTarget<QdrantOpType, String> typeAndTarget = op.getTypeAndTarget(
             QdrantOpType.class,
             String.class,

--- a/nb-adapters/adapter-qdrant/src/main/java/io/nosqlbench/adapter/qdrant/opdispensers/QdrantBaseOpDispenser.java
+++ b/nb-adapters/adapter-qdrant/src/main/java/io/nosqlbench/adapter/qdrant/opdispensers/QdrantBaseOpDispenser.java
@@ -50,14 +50,11 @@ public abstract class QdrantBaseOpDispenser<REQUEST,RESULT>
     private final LongFunction<REQUEST> paramF;
 
     protected QdrantBaseOpDispenser(QdrantDriverAdapter adapter, ParsedOp op, LongFunction<String> targetF) {
-        super((DriverAdapter)adapter, op);
+        super((DriverAdapter)adapter, op, adapter.getSpaceFunc(op));
         this.qdrantSpaceFunction = adapter.getSpaceFunc(op);
         this.clientFunction = (long l) -> this.qdrantSpaceFunction.apply(l).getClient();
         this.paramF = getParamFunc(this.clientFunction,op,targetF);
         this.opF = createOpFunc(paramF, this.clientFunction, op, targetF);
-    }
-    protected QdrantDriverAdapter getDriverAdapter() {
-        return (QdrantDriverAdapter) adapter;
     }
 
     public abstract LongFunction<REQUEST> getParamFunc(
@@ -74,8 +71,8 @@ public abstract class QdrantBaseOpDispenser<REQUEST,RESULT>
     );
 
     @Override
-    public QdrantBaseOp<REQUEST, RESULT> getOp(long value) {
-        return opF.apply(value);
+    public QdrantBaseOp<REQUEST, RESULT> getOp(long cycle) {
+        return opF.apply(cycle);
     }
 
     /**

--- a/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JOpMapper.java
+++ b/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/S4JOpMapper.java
@@ -19,18 +19,14 @@ package io.nosqlbench.adapter.s4j;
 import io.nosqlbench.adapter.s4j.dispensers.MessageConsumerOpDispenser;
 import io.nosqlbench.adapter.s4j.dispensers.MessageProducerOpDispenser;
 import io.nosqlbench.adapter.s4j.ops.S4JOp;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
-import io.nosqlbench.nb.api.config.standard.NBConfiguration;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import io.nosqlbench.engine.api.templating.TypeAndTarget;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public class S4JOpMapper implements OpMapper<S4JOp,S4JSpace> {
@@ -44,7 +40,7 @@ public class S4JOpMapper implements OpMapper<S4JOp,S4JSpace> {
     }
 
     @Override
-    public OpDispenser<S4JOp> apply(ParsedOp op, LongFunction<S4JSpace> spaceInitF) {
+    public OpDispenser<S4JOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<S4JSpace> spaceInitF) {
 
         /*
          * If the user provides a body element, then they want to provide the JSON or

--- a/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/dispensers/S4JBaseOpDispenser.java
+++ b/nb-adapters/adapter-s4j/src/main/java/io/nosqlbench/adapter/s4j/dispensers/S4JBaseOpDispenser.java
@@ -22,7 +22,6 @@ import io.nosqlbench.adapter.s4j.S4JSpace;
 import io.nosqlbench.adapter.s4j.ops.S4JOp;
 import io.nosqlbench.adapter.s4j.util.*;
 import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
-import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,7 +62,7 @@ public abstract  class S4JBaseOpDispenser extends BaseOpDispenser<S4JOp, S4JSpac
                                  ParsedOp op,
                                  LongFunction<String> destNameStrFunc) {
 
-        super(adapter, op);
+        super(adapter, op, adapter.getSpaceFunc(op));
 
         this.parsedOp = op;
 

--- a/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpDispenser.java
+++ b/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpDispenser.java
@@ -28,7 +28,7 @@ public class StdoutOpDispenser extends BaseOpDispenser<StdoutOp,StdoutSpace> {
     private final LongFunction<String> outFunction;
 
     public StdoutOpDispenser(DriverAdapter adapter, ParsedOp cmd, LongFunction<StdoutSpace> ctxfunc) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.ctxfunc = ctxfunc;
         LongFunction<Object> objectFunction = cmd.getAsRequiredFunction("stmt", Object.class);
         LongFunction<String> stringfunc = l -> objectFunction.apply(l).toString();
@@ -37,9 +37,9 @@ public class StdoutOpDispenser extends BaseOpDispenser<StdoutOp,StdoutSpace> {
     }
 
     @Override
-    public StdoutOp getOp(long value) {
-        StdoutSpace ctx = ctxfunc.apply(value);
-        String output = outFunction.apply(value);
+    public StdoutOp getOp(long cycle) {
+        StdoutSpace ctx = ctxfunc.apply(cycle);
+        String output = outFunction.apply(cycle);
         return new StdoutOp(ctx,output);
     }
 }

--- a/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpMapper.java
+++ b/nb-adapters/adapter-stdout/src/main/java/io/nosqlbench/adapter/stdout/StdoutOpMapper.java
@@ -19,11 +19,9 @@ package io.nosqlbench.adapter.stdout;
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
 import io.nosqlbench.adapters.api.activityimpl.uniform.DriverAdapter;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
-import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 public class StdoutOpMapper implements OpMapper<StdoutOp,StdoutSpace> {
@@ -35,7 +33,7 @@ public class StdoutOpMapper implements OpMapper<StdoutOp,StdoutSpace> {
     }
 
     @Override
-    public OpDispenser<StdoutOp> apply(ParsedOp op, LongFunction<StdoutSpace> spaceInitF) {
+    public OpDispenser<StdoutOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<StdoutSpace> spaceInitF) {
         return new StdoutOpDispenser(adapter,op,adapter.getSpaceFunc(op));
     }
 

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpDispenser.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpDispenser.java
@@ -27,7 +27,7 @@ public class TcpClientOpDispenser extends BaseOpDispenser<TcpClientOp, TcpClient
     private final LongFunction<String> outFunction;
 
     public TcpClientOpDispenser(TcpClientDriverAdapter adapter, ParsedOp cmd, LongFunction<TcpClientAdapterSpace> ctxfunc) {
-        super(adapter,cmd);
+        super(adapter,cmd, adapter.getSpaceFunc(cmd));
         this.ctxFunction = ctxfunc;
         LongFunction<Object> objectFunction = cmd.getAsRequiredFunction("stmt", Object.class);
         LongFunction<String> stringFunction = l -> objectFunction.apply(l).toString();
@@ -35,9 +35,9 @@ public class TcpClientOpDispenser extends BaseOpDispenser<TcpClientOp, TcpClient
     }
 
     @Override
-    public TcpClientOp getOp(long value) {
-        TcpClientAdapterSpace ctx = ctxFunction.apply(value);
-        String output = outFunction.apply(value);
+    public TcpClientOp getOp(long cycle) {
+        TcpClientAdapterSpace ctx = ctxFunction.apply(cycle);
+        String output = outFunction.apply(cycle);
         return new TcpClientOp(ctx,output);
     }
 }

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpMapper.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpclient/TcpClientOpMapper.java
@@ -18,9 +18,8 @@ package io.nosqlbench.adapter.tcpclient;
 
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -34,7 +33,7 @@ public class TcpClientOpMapper implements OpMapper<TcpClientOp,TcpClientAdapterS
     }
 
     @Override
-    public OpDispenser<TcpClientOp> apply(ParsedOp op, LongFunction<TcpClientAdapterSpace> spaceInitF) {
+    public OpDispenser<TcpClientOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<TcpClientAdapterSpace> spaceInitF) {
         LongFunction<String> spacefunc = op.getAsFunctionOr("space", "default");
         LongFunction<TcpClientAdapterSpace> ctxfunc = adapter.getSpaceFunc(op);
         return new TcpClientOpDispenser(adapter,op,ctxfunc);

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpDispenser.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpDispenser.java
@@ -27,7 +27,7 @@ public class TcpServerOpDispenser extends BaseOpDispenser<TcpServerOp,TcpServerA
     private final LongFunction<String> outFunction;
 
     public TcpServerOpDispenser(TcpServerDriverAdapter adapter, ParsedOp cmd, LongFunction<TcpServerAdapterSpace> ctxfunc) {
-        super(adapter,cmd);
+        super(adapter,cmd, ctxfunc);
         this.ctxFunction = ctxfunc;
         LongFunction<Object> objectFunction = cmd.getAsRequiredFunction("stmt", Object.class);
         LongFunction<String> stringFunction = l -> objectFunction.apply(l).toString();
@@ -35,9 +35,9 @@ public class TcpServerOpDispenser extends BaseOpDispenser<TcpServerOp,TcpServerA
     }
 
     @Override
-    public TcpServerOp getOp(long value) {
-        TcpServerAdapterSpace ctx = ctxFunction.apply(value);
-        String output = outFunction.apply(value);
+    public TcpServerOp getOp(long cycle) {
+        TcpServerAdapterSpace ctx = ctxFunction.apply(cycle);
+        String output = outFunction.apply(cycle);
         return new TcpServerOp(ctx,output);
     }
 }

--- a/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpMapper.java
+++ b/nb-adapters/adapter-tcp/src/main/java/io/nosqlbench/adapter/tcpserver/TcpServerOpMapper.java
@@ -18,9 +18,8 @@ package io.nosqlbench.adapter.tcpserver;
 
 import io.nosqlbench.adapters.api.activityimpl.OpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.OpMapper;
-import io.nosqlbench.adapters.api.activityimpl.uniform.ConcurrentSpaceCache;
-import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
+import io.nosqlbench.nb.api.components.core.NBComponent;
 
 import java.util.function.LongFunction;
 
@@ -34,7 +33,7 @@ public class TcpServerOpMapper implements OpMapper<TcpServerOp,TcpServerAdapterS
     }
 
     @Override
-    public OpDispenser<TcpServerOp> apply(ParsedOp op, LongFunction<TcpServerAdapterSpace> spaceInitF) {
+    public OpDispenser<TcpServerOp> apply(NBComponent adapterC, ParsedOp op, LongFunction<TcpServerAdapterSpace> spaceInitF) {
         LongFunction<String> spacefunc = op.getAsFunctionOr("space", "default");
         LongFunction<TcpServerAdapterSpace> ctxfunc = adapter.getSpaceFunc(op);
         return new TcpServerOpDispenser(adapter,op,ctxfunc);

--- a/nb-adapters/nb-adapters-included/pom.xml
+++ b/nb-adapters/nb-adapters-included/pom.xml
@@ -172,7 +172,7 @@
         <profile>
             <id>adapter-mongodb-include</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
@@ -186,7 +186,7 @@
         <profile>
             <id>adapter-pulsar-include</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
@@ -304,6 +304,20 @@
                 <dependency>
                     <groupId>io.nosqlbench</groupId>
                     <artifactId>adapter-gcp-spanner</artifactId>
+                    <version>${revision}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>adapter-example-include</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.nosqlbench</groupId>
+                    <artifactId>adapter-example</artifactId>
                     <version>${revision}</version>
                 </dependency>
             </dependencies>

--- a/nb-adapters/pom.xml
+++ b/nb-adapters/pom.xml
@@ -224,5 +224,15 @@
             </modules>
         </profile>
 
+        <profile>
+            <id>adapter-example-module</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>adapter-example</module>
+            </modules>
+        </profile>
+
     </profiles>
 </project>

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapter/diag/DriverAdapterLoader.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapter/diag/DriverAdapterLoader.java
@@ -24,6 +24,16 @@ import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 import io.nosqlbench.nb.api.labels.NBLabels;
 import io.nosqlbench.nb.api.components.core.NBComponent;
 
+/**
+ * <P>This service allows for the dynamic instancing of {@link DriverAdapter}s as services,
+ * using a well-defined method signature instead of (just) a no-args constructor. Since all key elements
+ * of the nosqlbench runtime are assembled into a component tree, each one requires an attachment
+ * point (parent) and child identifiers (label names and values) that uniquely describe it. This would typically be
+ * encoded as a constructor signature, however, there is no SPI mechanism which makes this easy to manage across JDPA
+ * and non-JDPA runtimes. So instead, we indirect this to a higher level service which has one and only one
+ * responsibility: to provide an instance through the well-defined API of {@link #load(NBComponent, NBLabels)}.
+ * </P>
+ */
 public interface DriverAdapterLoader {
-    public <A extends CycleOp<?>,B extends Space> DriverAdapter<A,B> load(NBComponent parent, NBLabels childLabels);
+    public <A extends CycleOp<?>, B extends Space> DriverAdapter<A, B> load(NBComponent parent, NBLabels childLabels);
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpDispenser.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpDispenser.java
@@ -78,12 +78,12 @@ public interface OpDispenser<OP extends CycleOp<?>> extends LongFunction<OP>, Op
      * additional processing if a caller wants to execute the operation
      * multiple times, as for retries.
      *
-     * @param value The cycle number which serves as the seed for any
+     * @param cycle The cycle number which serves as the seed for any
      *              generated op fields to be bound into an operation.
      * @return an executable operation
      */
 
-    OP getOp(long value);
+    OP getOp(long cycle);
 
     CycleFunction<Boolean> getVerifier();
 

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseSpace.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseSpace.java
@@ -20,6 +20,11 @@ package io.nosqlbench.adapters.api.activityimpl.uniform;
 
 import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 
+/**
+ * This example of a space uses the <EM>SelfT</EM> technique to enable
+ * the self type to be used in method signatures and return types.
+ * @param <SelfT>
+ */
 public class BaseSpace<SelfT extends BaseSpace<SelfT> > implements Space {
 
     private final String spaceName;

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/ConcurrentIndexCache.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/ConcurrentIndexCache.java
@@ -101,7 +101,7 @@ public class ConcurrentIndexCache<T> implements Iterable<T> {
                 return currentCache.get(key);
             }
         }
-        logger.debug(() -> "returning index[ " + key + " ] for [ " + label + " ] cache");
+        logger.trace(() -> "returning    index[ " + key + " ] for [ " + label + " ] cache");
 
         return value;
     }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/DriverAdapter.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/DriverAdapter.java
@@ -36,70 +36,95 @@ import java.util.function.Function;
 import java.util.function.LongFunction;
 
 /**
- * <P>The DriverAdapter interface is the replacement
- * for ActivityTypes. This interface takes a simpler
- * approach. Specifically, all of the core logic which was being pasted into each
- * driver type is centralized, and only the necessary interfaces
- * needed for construction new operations and shared context are exposed.
- * This means all drivers can now benefit from cross-cutting enhancements
- * in the core implementation.
+ * <P>The DriverAdapter interface is the top level API for implementing
+ * operations in NoSQLBench. It defines the related APIs needed to fully realized an adapter
+ * at runtime. A driver adapter can map op templates from YAML form to a fully executable
+ * form in native Java code, just as an application might do with a native driver. It can also
+ * do trivial operations, like simply calling {@code System.out.println(...)}. When you specify an adapter by name,
+ * you are choosing both the available operations, and the rules for converting a YAML op template into those
+ * operations. This is a two-step process: The adapter provides mapping logic for converting high-level templates from
+ * users into op types, and separate dispensing logic which can efficiently create these ops at runtime. When used
+ * together, they power <EM>op synthesis</EM> -- efficient and deterministic construction of runtime operations using
+ * procedural generation methods.
+ * </p>
+ *
+ * <p>
+ * Generally speaking, a driver adapter is responsible for
+ * <UL>
+ * <LI>Defining a class type for holding related state known as a {@link Space}.
+ * <UL><LI>The type of this is specified as
+ * generic parameter {@link SPACETYPE}.</LI></UL></LI>
+ * <LI>Defining a factory method for constructing an instance of the space.</LI>
+ * <LI>Recognizing the op templates that are documented for it via an {@link OpMapper}
+ * and assigning them to an op implementation.
+ * <UL><LI>The base type of these ops is specified as generic
+ * parameter {@link OPTYPE}.</LI></UL>
+ * </LI>
+ * <LI>Constructing dispensers for each matching op implementation with a matching {@link OpDispenser}</LI>
+ * implementation.
+ * </UL>
+ * <P>At runtime, the chain of these together ({@code cycle -> op mapping -> op dispensing -> op}) is cached
+ * as a look-up table of op dispensers. This results in the simpler logical form {@code cycle -> op synthesis ->
+ * operation}.
  * </P>
  *
- * @param <OPTYPE> The type of Runnable operation which will be used to wrap
- *            all operations for this driver adapter. This allows you to
- *            add context or features common to all operations of this
- *            type.
- * @param <SPACETYPE> The type of context space used by this driver to hold
- *            cached instances of clients, session, or other native driver
- *            esoterica. This is the shared state which might be needed
- *            during construction of R type operations, or even for individual
- *            operations.
+ * <H3>Variable Naming Conventions</H3>
+ * <p>
+ * Within the related {@link DriverAdapter} APIs, the following conventions are (more often) used, and will be found
+ * everywhere:
+ * <UL>
+ * <LI>{@code namedF} describes a namedFunction variable. Functional patterns are used everywhere in these APIs
+ * .</LI>
+ * <LI>{@code namedC} describes a namedComponent variable. All key elements of the nosqlbench runtime are
+ * part of a component tree.</LI>
+ * <LI>{@code pop} describes a {@link ParsedOp} instance.</LI>
+ * </UL>
+ * </P>
+ * <H3>Generic Parameters</H3>
+ * <p>
+ * When a new driver adapter is defined with the generic parameters below, it becomes easy to build out a matching
+ * DriverAdapter with any modern IDE.</P>
+ *
+ * @param <OPTYPE>
+ *     The type of {@link CycleOp} which will be used to wrap all operations for this driver adapter. This allows you
+ *     to add context or features common to all operations of this type. This can be a simple <a
+ *     href="https://en.wikipedia.org/wiki/Marker_interface_pattern">Marker</a> interface, or it can be something more
+ *     concrete that captures common logic or state across all the operations used for a given adapter. It is highly
+ *     advised to <EM>NOT</EM> leave it as simply {@code CycleOp<?>}, since specific op implementations offer much
+ *     better performance.
+ * @param <SPACETYPE>
+ *     The type of context space used by this driver to hold cached instances of clients, session, or other native
+ *     driver state. This is the shared state which might be needed during construction operations for an adapter.
+ *     <EM>No other mechanism is provided nor intended for holding adapter-specific state. You must store it in
+ *     this type. This includes client instances, codec mappings, or anything else that a single instance of an
+ *     application would need to effectively use a given native driver.</EM>
  */
 public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Space> extends NBComponent {
 
     /**
      * <p>
      * <H2>Op Mapping</H2>
-     * An Op Mapper is a function which can look at the parsed
-     * fields in a {@link ParsedOp} and create an OpDispenser.
-     * An OpDispenser is a function that will produce a special
-     * type {@link OPTYPE} that this DriverAdapter implements as its
-     * op implementation.</p>
+     * An Op Mapper is a function which can look at a {@link ParsedOp} and create a matching {@link OpDispenser}.
+     * An OpDispenser is a function that will produce a special type {@link OPTYPE} that this DriverAdapter implements
+     * as its op implementation. There may be many different ops supported by an adapter, thus there may be similarly
+     * many dispensers.</p>
      *
      * <p>
-     * The function that is returned is responsible for creating another function.
-     * This might seem counter-intuitive but it is very intentional because
-     * of these design constraints:
-     * <UL>
-     * <LI>Mapping op semantics to a type of operation must be very clear
-     * and flexible. Performance is not important at this layer because this is all done
-     * during initialization time for an activity.</LI>
-     * <LI>Synthesizing executable operations from a known type of operational template
-     * must be done very efficiently. This part is done during activity execution, so
-     * having the details of how you are going to create an op for execution already
-     * sorted out is important.</LI>
-     * </UL>
+     * Both {@link OpMapper} and {@link OpDispenser} are functions. The role of {@link OpMapper} is to
+     * map the op template provided by the user to an op implementation provided by the driver adapter,
+     * and then to create a factor function for it (the {@link OpDispenser}).</p>
      *
-     * To clarify the distinction between these two phases, the first is canonically
-     * called <em>op mapping</em> in the documentation. The second is called
-     * <em>op synthesis</em>.
+     * <p>These roles are split for a very good reason: Mapping what the user wants to do with an op template
+     * is resource intenstive, and should be as pre-baked as possible. This phase is the <EM>op mapping</EM> phase.
+     * It is essential that the mapping logic be very clear and maintainable. Performance is not as important
+     * at this phase, because all of the mapping logic is run during initialization of an activity.
      * </p>
-     *
      * <p>
-     * <H2>A note on implementation strategy:</H2>
-     * Generally speaking, implementations of this method should interrogate the op fields
-     * in the ParsedOp and return an OpDispenser that matches the user's intentions.
-     * This can be based on something explicit, like the  value of a {@code type} field,
-     * or it can be based on whether certain fields are present or not. Advanced implementations
-     * might take into account which fields are provided as static values and which are
-     * specified as bindings. In any case, the op mapping phase is meant to qualify and
-     * pre-check that the fields provided are valid and specific for a given type of operation.
-     * What happens within {@link OpDispenser} implementations (the second phase), however, should do
-     * as little qualification of field values as possible, focusing simply on constructing
-     * the type of operation for which they are designed.
+     * Conversely, <EM>op dispensing</EM> (the next phase) while an activity is running should be as efficient as
+     * possible.
      * </p>
      *
-     * @return a synthesizer function for {@link OPTYPE} op generation
+     * @return a dispensing function for {@link OPTYPE} op generation
      */
     OpMapper<OPTYPE, SPACETYPE> getOpMapper();
 
@@ -108,7 +133,8 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
      * the fields in the op template before they are interpreted canonically.
      * At this level, the transform is applied once to the input map
      * (once per op template) to yield the map that is provided to
-     * {@link OpMapper} implementations.
+     * {@link OpMapper} implementations. <EM>This is here to make backwards compatibility
+     * possible for op templates which have changed. Avoid using it unless necessary.</EM>
      *
      * @return A function to pre-process the op template fields.
      */
@@ -121,28 +147,29 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
      * routing it to the correct error handler, or naming it in logs, or naming
      * metrics, override this method in your activity.
      *
-     * @return A function that can reliably and safely map an instance of Throwable to a stable name.
+     * @return A function that can reliably and safely map an instance of Throwable to a stable adapter-specific name.
      */
     default Function<Throwable, String> getErrorNameMapper() {
         return t -> t.getClass().getSimpleName();
     }
 
-    default List<Function<Map<String,Object>,Map<String,Object>>> getOpFieldRemappers() {
+    default List<Function<Map<String, Object>, Map<String, Object>>> getOpFieldRemappers() {
         return List.of(f -> f);
     }
 
-//    ConcurrentSpaceCache<SPACETYPE> getSpaceCache();
-
     /**
-     * This method allows each driver adapter to create named state which is automatically
+     * <P>This method allows each driver adapter to create named state which is automatically
      * cached and re-used by name. For each (driver,space) combination in an activity,
      * a distinct space instance will be created. In general, adapter developers will
      * use the space type associated with an adapter to wrap native driver instances
      * one-to-one. As such, if the space implementation is a {@link AutoCloseable},
-     * it will be explicitly shutdown as part of the activity shutdown.
+     * it will be explicitly shutdown as part of the activity shutdown.</P>
+     *
+     * <p>It is not necessary to implement a space for a stateless driver adapter, or one
+     * which puts all state into each op instance.</p>
      *
      * @return A function which can initialize a new Space, which is a place to hold
-     * object state related to retained objects for the lifetime of a native driver.
+     *     object state related to retained objects for the lifetime of a native driver.
      */
     default LongFunction<SPACETYPE> getSpaceInitializer(NBConfiguration cfg) {
         return n -> (SPACETYPE) new Space() {
@@ -162,8 +189,11 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
      *     markdown file for this driver adapter.</li>
      *     <li>&lt;resources&gt;/docs/&lt;adaptername&gt;/ - A directory containing any type of file which
      *     is to be included in docs under the adapter name, otherwise known as the {@link Service#selector()}</li>
+     *     <li>&lt;resources&gt;/docs/&lt;adaptername&gt;.md</li>
      * </ul>
-     * path &lt;resources&gt;/docs/&lt;adaptername&gt;. Specifically, the file
+     *
+     * <P><EM>A build will fail if any driver adapter implementation is missing at least one self-named
+     * markdown doc file.</EM></P>
      *
      * @return A {@link DocsBinder} which describes docs to include for a given adapter.
      */
@@ -184,7 +214,7 @@ public interface DriverAdapter<OPTYPE extends CycleOp<?>, SPACETYPE extends Spac
 
     default String getAdapterName() {
         Service svc = this.getClass().getAnnotation(Service.class);
-        if (svc==null) {
+        if (svc == null) {
             throw new RuntimeException("The Service annotation for adapter of type " + this.getClass().getCanonicalName() + " is missing.");
         }
         return svc.selector();

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/flowtypes/CycleOp.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/flowtypes/CycleOp.java
@@ -23,25 +23,25 @@ import java.util.function.LongFunction;
 
 /**
  * <H2>CycleOp: f(cycle) -> T</H2>
- * <p>A CycleOp of T is an operation which takes a long input value
- * and produces a value of type T. It is implemented as
+ * <p>A CycleOp of T is an operation which takes a long input value and produces a value of type T. It is implemented as
  * {@link LongFunction} of T.</p>
  *
  * <h2>Designer Notes</h2>
  * <p>
- * If you are using the value in this call to select a specific type of behavior, it is very
- * likely a candidate for factoring into separate op implementations.
- * The {@link OpMapper}
- * and {@link OpDispenser} abstractions are meant to move
- * op type selection and scheduling to earlier in the activity.
+ * If you are using the value in this call to select a specific type of behavior, i.e.
+ * among a variety of operation types, it is very likely a candidate for factoring
+ * into separate op implementations. By using the <pre>cycle -> mapper -> dispenser -> op</pre>
+ * pattern to move as much of the initialization logic forward, you will have
+ * much more efficient operations and much cleaner code. The {@link OpMapper}
+ * and {@link OpDispenser} abstractions are meant to move op type selection and scheduling to earlier in the activity.
  * </p>
- *
  */
 public interface CycleOp<T> extends LongFunction<T> {
     /**
      * <p>Run an action for the given cycle.</p>
      *
-     * @param value The cycle value for which an operation is run
+     * @param value
+     *     The cycle value for which an operation is run
      */
     @Override
     T apply(long value);

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/DryCycleOpDispenserWrapper.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/DryCycleOpDispenserWrapper.java
@@ -32,7 +32,7 @@ public class DryCycleOpDispenserWrapper<S extends Space, RESULT> extends BaseOpD
         ParsedOp pop,
         OpDispenser<CycleOp<RESULT>> realDispenser
     ) {
-        super(adapter, pop);
+        super(adapter, pop, adapter.getSpaceFunc(pop));
         this.realDispenser = realDispenser;
         logger.warn(
             "initialized {} for dry run only. " +

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/EmitterCycleOpDispenserWrapper.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/EmitterCycleOpDispenserWrapper.java
@@ -32,7 +32,7 @@ public class EmitterCycleOpDispenserWrapper<O,S extends Space,R> extends BaseOpD
         ParsedOp pop,
         OpDispenser<CycleOp<R>> realDispenser
     ) {
-        super(adapter, pop);
+        super(adapter, pop, adapter.getSpaceFunc(pop));
         this.realDispenser = realDispenser;
         logger.warn(
             "initialized {} for to emit the result type to stdout. ",

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/EmitterOpDispenserWrapper.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/opwrappers/EmitterOpDispenserWrapper.java
@@ -29,7 +29,7 @@ public class EmitterOpDispenserWrapper extends BaseOpDispenser<CycleOp<?>, Space
 
     public EmitterOpDispenserWrapper(DriverAdapter<CycleOp<?>,Space> adapter, ParsedOp pop,
                                      OpDispenser<? extends CycleOp<?>> realDispenser) {
-        super(adapter, pop);
+        super(adapter, pop, adapter.getSpaceFunc(pop));
         this.realDispenser = realDispenser;
     }
     @Override

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/activityimpl/SimpleActivity.java
@@ -425,7 +425,7 @@ public class SimpleActivity extends NBStatusComponent implements Activity, Invok
                     DriverAdapter<CycleOp<?>, Space> adapter = adapters.get(i);
                     OpMapper<CycleOp<?>, Space> opMapper = adapter.getOpMapper();
                     LongFunction<Space> spaceFunc = adapter.getSpaceFunc(pop);
-                    OpDispenser<CycleOp<?>> dispenser = opMapper.apply(pop, spaceFunc);
+                    OpDispenser<CycleOp<?>> dispenser = opMapper.apply(this, pop, spaceFunc);
                     String dryrunSpec = pop.takeStaticConfigOr("dryrun", "none");
                     dispenser = OpWrappers.wrapOptionally(adapter, dispenser, pop, dryrunSpec);
 


### PR DESCRIPTION
Key changes here:
- Improved the adapter API and updated call sites
- Added an example driver adapter
- Squelched the session leak indicator by default in CQL to support many-session testing
- Included process-level open file descriptor count in metrics

Reviewers may benefit from selecting specific commits, since the refactoring noise is isolated to a couple, and the others are self-evident