### PR TITLE
Update build.yml to run builddocs on pull_request events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
   builddocs:
     needs: build
     runs-on: ubuntu-22.04
-    if: ${{ github.repository == 'nosqlbench/nosqlbench' && github.event_name == 'push' && github.ref_name == 'main' }}
+    if: ${{ github.repository == 'nosqlbench/nosqlbench' && github.event_name == 'pull_request' && github.ref_name == 'main' }}
     steps:
 
       - name: set git username


### PR DESCRIPTION
When I took the double build workflow triggers away the builddocs step stopped being triggered.