### PR TITLE
Jshook/annotate spaces

### DIFF
--- a/mvn-defaults/pom.xml
+++ b/mvn-defaults/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
 
-        <revision>5.21.8-SNAPSHOT</revision>
+        <revision>5.21.9-SNAPSHOT</revision>
         <!-- Set this level to override the logging level for tests during build -->
         <project.testlevel>INFO</project.testlevel>
         <!-- Set this level to override the logging level for tests logging configuration during build -->

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
@@ -247,4 +247,58 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>, SPACE extends Space
         OP op = getOp(value);
         return op;
     }
+
+    @Override
+    public Map<String, String> getErrorContext() {
+        return Map.of("space_name", "unknown");
+    }
+
+    /**
+     * Get the error context for a specific cycle value.
+     * This method returns a map containing the space name for the given cycle value.
+     *
+     * @param cycleValue The cycle value to get the error context for
+     * @return A map containing the space name for the given cycle value
+     */
+    @Override
+    public Map<String, String> getErrorContextForCycle(long cycleValue) {
+        String spaceName = getSpaceNameForCycle(cycleValue);
+        return Map.of("space_name", spaceName);
+    }
+
+    /**
+     * Get the name of the space for a given cycle value.
+     * This method uses the spaceNameF function to convert a cycle value to a name.
+     * If spaceNameF is null, it returns the string value of the cycle.
+     *
+     * @param cycleValue The cycle value to get the name for
+     * @return The name of the space for the given cycle value, or the string value of the cycle if spaceNameF is null
+     */
+    public String getSpaceNameForCycle(long cycleValue) {
+        if (spaceNameF == null) {
+            return String.valueOf(cycleValue);
+        }
+        return spaceNameF.apply(cycleValue);
+    }
+
+    /**
+     * Modify an exception message by prepending the space name, but only if the space name is not the default one.
+     * This method is used to provide more context in error messages.
+     *
+     * @param error The original exception to modify
+     * @param cycleValue The cycle value associated with the exception
+     * @return The modified message with the space name prepended if applicable, or the original message
+     */
+    @Override
+    public RuntimeException modifyExceptionMessage(Exception error, long cycleValue) {
+        if (spaceNameF == BaseDriverAdapter.DEFAULT_CYCLE_TO_SPACE_F) {
+            if (error instanceof RuntimeException re) {
+                return re;
+            } else {
+                return new RuntimeException(error);
+            }
+        }
+        String spaceName = getSpaceNameForCycle(cycleValue);
+        return new RuntimeException("Error in space '" + spaceName + "': " + error.getMessage(), error);
+    }
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/BaseOpDispenser.java
@@ -18,8 +18,10 @@ package io.nosqlbench.adapters.api.activityimpl;
 
 import com.codahale.metrics.Timer;
 import groovy.lang.Binding;
+import io.nosqlbench.adapters.api.activityimpl.uniform.BaseDriverAdapter;
 import io.nosqlbench.adapters.api.activityimpl.uniform.Space;
 import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
+import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.NBErrorContext;
 import io.nosqlbench.adapters.api.evalctx.*;
 import io.nosqlbench.adapters.api.metrics.ThreadLocalNamedTimers;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
@@ -37,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
+import java.util.function.LongToIntFunction;
 
 /**
  * See {@link OpDispenser} for details on how to use this type.
@@ -48,7 +51,8 @@ import java.util.function.LongFunction;
  *     The type of operation
  */
 public abstract class BaseOpDispenser<OP extends CycleOp<?>, SPACE extends Space>
-    extends NBBaseComponent implements OpDispenser<OP> {
+    extends NBBaseComponent implements OpDispenser<OP>, NBErrorContext
+{
     protected final static Logger logger = LogManager.getLogger(BaseOpDispenser.class);
     public static final String VERIFIER = "verifier";
     public static final String VERIFIER_INIT = "verifier-init";
@@ -56,6 +60,7 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>, SPACE extends Space
     public static final String VERIFIER_IMPORTS = "verifier-imports";
     public static final String START_TIMERS = "start-timers";
     public static final String STOP_TIMERS = "stop-timers";
+
 
     private final String opName;
     private final NBLabels labels;
@@ -66,6 +71,7 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>, SPACE extends Space
     private final String[] timerStarts;
     private final String[] timerStops;
     protected LongFunction<? extends SPACE> spaceF;
+    protected LongFunction<String> spaceNameF;
 
     /**
      * package imports used with "verifiers" or "expected-result" are accumulated here
@@ -81,9 +87,20 @@ public abstract class BaseOpDispenser<OP extends CycleOp<?>, SPACE extends Space
     private final ThreadLocal<CycleFunction<Boolean>> tlVerifier;
 
     protected BaseOpDispenser(final NBComponent parentC, final ParsedOp op, LongFunction<? extends SPACE> spaceF) {
+        this(parentC, op, spaceF, null);
+    }
+
+    protected BaseOpDispenser(final NBComponent parentC, final ParsedOp op, LongFunction<? extends SPACE> spaceF, LongFunction<String> spaceNameF) {
         super(parentC);
         opName = op.getName();
         labels = op.getLabels();
+        this.spaceF = spaceF;
+        this.spaceNameF = spaceNameF;
+
+        // If parentC is a DriverAdapter and spaceNameF is null, get the naming function from it
+        if (this.spaceNameF == null && parentC instanceof io.nosqlbench.adapters.api.activityimpl.uniform.BaseDriverAdapter) {
+            this.spaceNameF = ((io.nosqlbench.adapters.api.activityimpl.uniform.BaseDriverAdapter<?, ?>) parentC).getSpaceNameFunc(op);
+        }
 
         this.timerStarts = op.takeOptionalStaticValue(START_TIMERS, String.class)
             .map(s -> s.split(", *"))

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpDispenser.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/OpDispenser.java
@@ -21,6 +21,7 @@ import io.nosqlbench.adapters.api.evalctx.CycleFunction;
 import io.nosqlbench.adapters.api.activityconfig.yaml.OpTemplate;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
 
+import java.util.Map;
 import java.util.function.LongFunction;
 
 ///  ## Synopsis
@@ -109,4 +110,23 @@ public interface OpDispenser<OPTYPE extends CycleOp<?>> extends LongFunction<OPT
     CycleFunction<Boolean> getVerifier();
 
     String getOpName();
+
+    /**
+     * Get the error context for a specific cycle value.
+     * This method returns a map containing the space name for the given cycle value.
+     *
+     * @param cycleValue The cycle value to get the error context for
+     * @return A map containing the space name for the given cycle value
+     */
+    Map<String, String> getErrorContextForCycle(long cycleValue);
+
+    /**
+     * Modify an exception  by prepending the space name, but only if it's not the default one.
+     * This method is used to provide more context in error messages.
+     *
+     * @param error The original exception  to modify
+     * @param cycleValue The cycle value associated with the exception
+     * @return The modified message with the space name prepended if applicable, or the original message
+     */
+    RuntimeException modifyExceptionMessage(Exception error, long cycleValue);
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseDriverAdapter.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseDriverAdapter.java
@@ -194,13 +194,39 @@ public abstract class BaseDriverAdapter<RESULT
             .asReadOnly();
     }
 
+    /**
+     * Get the function that names space indexes for a given cycle value.
+     * This method extracts the naming function from the getSpaceFunc method.
+     *
+     * @param pop The parsed op
+     * @return A function that converts a cycle value to a name, or null if no naming function is available
+     */
+    public LongFunction<String> getSpaceNameFunc(ParsedOp pop) {
+        Optional<LongFunction<Object>> spaceFuncTest = pop.getAsOptionalFunction("space", Object.class);
+        if (spaceFuncTest.isEmpty()) {
+            return null;
+        }
+
+        Object example = spaceFuncTest.get().apply(0L);
+        if (example instanceof Number) {
+            return null;
+        } else {
+            LongFunction<?> sourceF = pop.getAsRequiredFunction("space", String.class);
+            final LongFunction<?> finalSourceF = sourceF;
+            return l -> finalSourceF.apply(l).toString();
+        }
+    }
+
     @Override
     public LongFunction<SPACE> getSpaceFunc(ParsedOp pop) {
 
         Optional<LongFunction<Object>> spaceFuncTest = pop.getAsOptionalFunction("space", Object.class);
+        ConcurrentIndexCacheWrapperWithName wrapper = null;
+        LongFunction<String> namerF = null;
         LongToIntFunction cycleToSpaceF;
+
         if (spaceFuncTest.isEmpty()) {
-            cycleToSpaceF = (long l) -> 0;
+            cycleToSpaceF = DEFAULT_CYCLE_TO_SPACE_F;
         } else {
             Object example = spaceFuncTest.get().apply(0L);
             if (example instanceof Number n) {
@@ -210,14 +236,48 @@ public abstract class BaseDriverAdapter<RESULT
             } else {
                 logger.trace("mapping space indirectly through hash table to index pool");
                 LongFunction<?> sourceF = pop.getAsRequiredFunction("space", String.class);
-                LongFunction<String> namerF = l -> sourceF.apply(l).toString();
-                ConcurrentIndexCacheWrapper wrapper = new ConcurrentIndexCacheWrapper();
-                cycleToSpaceF = l -> wrapper.mapKeyToIndex(namerF.apply(l));
+                final LongFunction<?> finalSourceF = sourceF;
+                namerF = l -> finalSourceF.apply(l).toString();
+                wrapper = new ConcurrentIndexCacheWrapperWithName();
+                final ConcurrentIndexCacheWrapperWithName finalWrapper = wrapper;
+                final LongFunction<String> finalNamerF = namerF;
+                cycleToSpaceF = l -> finalWrapper.mapKeyToIndex(finalNamerF.apply(l));
             }
         }
 
         ConcurrentSpaceCache<SPACE> spaceCache1 = getSpaceCache();
-        return l -> spaceCache1.get(cycleToSpaceF.applyAsInt(l));
+        final LongToIntFunction finalCycleToSpaceF = cycleToSpaceF;
+
+        // If we're using the wrapper, capture it in the final variables for the lambda
+        final ConcurrentIndexCacheWrapperWithName finalWrapper = wrapper;
+
+        if (finalWrapper != null) {
+            return l -> {
+                int spaceIndex = finalCycleToSpaceF.applyAsInt(l);
+                SPACE space = spaceCache1.get(spaceIndex);
+
+                // If the space is a BaseSpace, set the original name
+                if (space instanceof BaseSpace) {
+                    String nameForIndex = finalWrapper.getNameForIndex(spaceIndex);
+                    // Ensure the original name is never null
+                    ((BaseSpace<?>) space).setOriginalName(nameForIndex != null ? nameForIndex : String.valueOf(spaceIndex));
+                }
+
+                return space;
+            };
+        } else {
+            return l -> {
+                int spaceIndex = finalCycleToSpaceF.applyAsInt(l);
+                SPACE space = spaceCache1.get(spaceIndex);
+
+                // If the space is a BaseSpace, set the original name to the string value of the index
+                if (space instanceof BaseSpace) {
+                    ((BaseSpace<?>) space).setOriginalName(String.valueOf(spaceIndex));
+                }
+
+                return space;
+            };
+        }
     }
 
     @Override

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseDriverAdapter.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseDriverAdapter.java
@@ -16,6 +16,7 @@
 
 package io.nosqlbench.adapters.api.activityimpl.uniform;
 
+import io.nosqlbench.adapters.api.activityimpl.BaseOpDispenser;
 import io.nosqlbench.adapters.api.activityimpl.uniform.fieldmappers.FieldDestructuringMapper;
 import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 import io.nosqlbench.adapters.api.templating.ParsedOp;
@@ -293,4 +294,11 @@ public abstract class BaseDriverAdapter<RESULT
         }
         super.beforeDetach();
     }
+
+    /**
+     * The default cycle to space function used when no custom space mapper is provided.
+     * This is used to determine if a custom space mapper has been provided.
+     */
+    public static final LongToIntFunction DEFAULT_CYCLE_TO_SPACE_F = (long l) -> 0;
+
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseSpace.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/BaseSpace.java
@@ -31,11 +31,37 @@ import io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes.CycleOp;
 public class BaseSpace<SelfT extends BaseSpace<SelfT> > implements Space {
 
     private final String spaceName;
+    private String originalName;
     private final DriverAdapter<?, SelfT> adapter;
 
     public BaseSpace(DriverAdapter<?,SelfT> adapter, long idx) {
+        this(adapter, idx, String.valueOf(idx));
+    }
+
+    public BaseSpace(DriverAdapter<?,SelfT> adapter, long idx, String originalName) {
         this.spaceName = String.valueOf(idx);
         this.adapter = adapter;
+        this.originalName = originalName;
+    }
+
+    /**
+     * Set the original name (string representation of the key) for this space.
+     * This is used when a space is created via ConcurrentIndexCacheWrapperWithName.
+     *
+     * @param originalName The original name for this space
+     */
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
+    /**
+     * Get the original name (string representation of the key) for this space.
+     * This may be null if the space was not created via ConcurrentIndexCacheWrapperWithName.
+     *
+     * @return The original name for this space, or null if not set
+     */
+    public String getOriginalName() {
+        return originalName;
     }
 
     @Override
@@ -46,6 +72,10 @@ public class BaseSpace<SelfT extends BaseSpace<SelfT> > implements Space {
     public static class BasicSpace extends BaseSpace<BasicSpace> implements Space {
         public BasicSpace(DriverAdapter<? extends CycleOp<?>, BasicSpace> adapter, long idx) {
             super(adapter, idx);
+        }
+
+        public BasicSpace(DriverAdapter<? extends CycleOp<?>, BasicSpace> adapter, long idx, String originalName) {
+            super(adapter, idx, originalName);
         }
     }
 }

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/ConcurrentIndexCacheWrapperWithName.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/ConcurrentIndexCacheWrapperWithName.java
@@ -1,0 +1,58 @@
+package io.nosqlbench.adapters.api.activityimpl.uniform;
+
+/*
+ * Copyright (c) nosqlbench
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An extension of ConcurrentIndexCacheWrapper that also provides access to the original key name.
+ * This allows Space implementations to be initialized with the original String value used in the wrapper.
+ */
+public class ConcurrentIndexCacheWrapperWithName {
+
+    private final ConcurrentHashMap<Object, Integer> forwardMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> indexToNameMap = new ConcurrentHashMap<>();
+
+    /**
+     * Maps a key to an index and stores the key's string representation for later retrieval.
+     *
+     * @param key The key to map to an index
+     * @return The index for the key
+     */
+    public int mapKeyToIndex(Object key) {
+        Integer index = forwardMap.computeIfAbsent(key, this::nextIndex);
+        // Store the key's string representation if it's not already stored
+        indexToNameMap.computeIfAbsent(index, idx -> key.toString());
+        return index;
+    }
+
+    /**
+     * Gets the original name (string representation of the key) for a given index.
+     *
+     * @param index The index to get the name for
+     * @return The name associated with the index, or null if not found
+     */
+    public String getNameForIndex(int index) {
+        return indexToNameMap.get(index);
+    }
+
+    private int idx = 0;
+    private synchronized int nextIndex(Object any) {
+        return idx++;
+    }
+}

--- a/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/flowtypes/NBErrorContext.java
+++ b/nb-apis/adapters-api/src/main/java/io/nosqlbench/adapters/api/activityimpl/uniform/flowtypes/NBErrorContext.java
@@ -1,0 +1,26 @@
+package io.nosqlbench.adapters.api.activityimpl.uniform.flowtypes;
+
+/*
+ * Copyright (c) nosqlbench
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import java.util.Map;
+
+public interface NBErrorContext {
+  public Map<String,String> getErrorContext();
+
+}

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Beta.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Beta.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.BetaDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Beta_distribution">Wikipedia: Beta distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/BetaDistribution.html">Commons JavaDoc: BetaDistribution</a>
- *
- * {@inheritDoc}
  */
 @Categories({Category.distributions})
 @ThreadSafeMapper

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Cauchy.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Cauchy.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.CauchyDistribution;
  * @see <a href="http://en.wikipedia.org/wiki/Cauchy_distribution">Wikipedia: Cauchy_distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/CauchyDistribution.html">Commons Javadoc: CauchyDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/ChiSquared.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/ChiSquared.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.ChiSquaredDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Chi-squared_distribution">Wikipedia: Chi-squared distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/ChiSquaredDistribution.html">Commons JavaDoc: ChiSquaredDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/ConstantContinuous.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/ConstantContinuous.java
@@ -26,7 +26,6 @@ import org.apache.commons.math4.legacy.distribution.EmpiricalDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/ConstantContinuousDistribution.html">Commons JavaDoc: ConstantContinuousDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Enumerated.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Enumerated.java
@@ -28,7 +28,6 @@ import org.apache.commons.math4.legacy.distribution.EnumeratedRealDistribution;
  *
  * @see <a href="http://commons.apache.org/proper/commons-math/apidocs/org/apache/commons/math4/distribution/EnumeratedRealDistribution.html">Commons JavaDoc: EnumeratedRealDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Exponential.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Exponential.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.ExponentialDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/ExponentialDistribution.html">Commons JavaDoc: ExponentialDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/F.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/F.java
@@ -28,7 +28,6 @@ import org.apache.commons.statistics.distribution.FDistribution;
  *
  * @see <a href="http://mathworld.wolfram.com/F-Distribution.html">Mathworld: F-Distribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Gamma.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Gamma.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.GammaDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/GammaDistribution.html">Commons JavaDoc: GammaDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Gumbel.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Gumbel.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.GumbelDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/GumbelDistribution.html">Commons JavaDoc: GumbelDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Laplace.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Laplace.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.LaplaceDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/LaplaceDistribution.html">Commons JavaDoc: LaplaceDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Levy.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Levy.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.LevyDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/LevyDistribution.html">Commons JavaDoc: LevyDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/LogNormal.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/LogNormal.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.LogNormalDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Log-normal_distribution">Wikipedia: Log-normal distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/LogNormalDistribution.html">Commons JavaDoc: LogNormalDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Logistic.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Logistic.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.LogisticDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Logistic_distribution">Wikipedia: Logistic distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/LogisticDistribution.html">Commons JavaDoc: LogisticDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Nakagami.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Nakagami.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.NakagamiDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Nakagami_distribution">Wikipedia: Nakagami distribution</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/NakagamiDistribution.html">Commons JavaDoc: NakagamiDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Normal.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Normal.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.NormalDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/NormalDistribution.html">Commons JavaDoc: NormalDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Pareto.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Pareto.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.ParetoDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/ParetoDistribution.html">Commons JavaDoc: ParetoDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/T.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/T.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.TDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/TDistribution.html">Commons JavaDoc: TDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Triangular.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Triangular.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.TriangularDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/TriangularDistribution.html">Commons JavaDoc: TriangularDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Uniform.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Uniform.java
@@ -25,8 +25,6 @@ import org.apache.commons.statistics.distribution.UniformContinuousDistribution;
  * @see <a href="https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)">Wikipedia: Uniform distribution (continuous)</a>
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/UniformContinuousDistribution.html">Commons JavaDoc: UniformContinuousDistribution</a>
- *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Weibull.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/continuous/int_double/Weibull.java
@@ -28,7 +28,6 @@ import org.apache.commons.statistics.distribution.WeibullDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/WeibullDistribution.html">Commons Javadoc: WeibullDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Binomial.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Binomial.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.BinomialDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/BinomialDistribution.html">Commons JavaDoc: BinomialDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Geometric.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Geometric.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.GeometricDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/GeometricDistribution.html">Commons JavaDoc: GeometricDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Hypergeometric.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Hypergeometric.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.HypergeometricDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/HypergeometricDistribution.html">Commons JavaDoc: HypergeometricDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Pascal.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Pascal.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.PascalDistribution;
  *
  * @see <a href="https://en.wikipedia.org/wiki/Negative_binomial_distribution">Wikipedia: Negative binomial distribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Poisson.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Poisson.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.PoissonDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/PoissonDistribution.html">Commons JavaDoc: PoissonDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})

--- a/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Zipf.java
+++ b/nb-virtdata/virtdata-lib-curves4/src/main/java/io/nosqlbench/virtdata/library/curves4/discrete/int_int/Zipf.java
@@ -26,7 +26,6 @@ import org.apache.commons.statistics.distribution.ZipfDistribution;
  *
  * @see <a href="https://commons.apache.org/proper/commons-statistics/commons-statistics-distribution/apidocs/org/apache/commons/statistics/distribution/ZipfDistribution.html">Commons JavaDoc: ZipfDistribution</a>
  *
- * {@inheritDoc}
  */
 @ThreadSafeMapper
 @Categories({Category.distributions})


### PR DESCRIPTION
These changes improve error messaging when spaces are used to create many clients.
Both the binding phase and the execution phase of a cycle are instrumented to prepend the space name when the default non-variant space function is bypassed with custom values.