### PR TITLE
Default TLS version updated to TLSv1.3 and add TLSv1.3 test

### DIFF
--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/util/SSLKsFactory.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/util/SSLKsFactory.java
@@ -49,7 +49,7 @@ public class SSLKsFactory implements NBMapConfigurable {
             "{1,10}([a-z0-9+/=\\r\\n]+)-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", Pattern.CASE_INSENSITIVE);
 
     public static final String SSL = "ssl";
-    public static final String DEFAULT_TLSVERSION = "TLSv1.2";
+    public static final String DEFAULT_TLSVERSION = "TLSv1.3";
 
     private static final TrustManager[] trustAllCerts = new TrustManager[]{
             new X509TrustManager() {

--- a/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/util/SSLKsFactoryTest.java
+++ b/nb-engine/nb-engine-core/src/test/java/io/nosqlbench/engine/api/util/SSLKsFactoryTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 
+import javax.net.ssl.SSLContext;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -307,6 +309,19 @@ public class SSLKsFactoryTest {
                 .isThrownBy(() -> SSLKsFactory.get().getContext(sslCfg))
                 .withMessageContaining("Unable to load key from")
                 .withCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testJdkGetContextTLS13() {
+        String[] params = {
+            "ssl=jdk",
+            "tlsversion=TLSv1.3"
+       };
+        ActivityDef activityDef = ActivityDef.parseActivityDef(String.join(";", params));
+        NBConfiguration sslCfg = SSLKsFactory.get().getConfigModel().extractConfig(activityDef.getParams());
+        SSLContext ctx = SSLKsFactory.get().getContext(sslCfg);
+        assertThat(ctx).isNotNull();
+        assertThat(ctx.getProtocol()).isEqualTo("TLSv1.3");
     }
 
 }


### PR DESCRIPTION
### Summary

This PR updates the default TLS protocol version in `SSLKsFactory` from `TLSv1.2` to `TLSv1.3`.

### Why

Modern JDKs support TLSv1.3, which offers:

- Better performance (fewer handshake round-trips)
- Stronger security
- Simplified cipher suites

NoSQLBench already allows users to specify `tlsversion=TLSv1.3`, so the upgrade is backwards compatible. Users who require TLSv1.2 may still configure it explicitly.

### Changes

- Updated DEFAULT_TLSVERSION → `TLSv1.3`
- Added a unit test to confirm that `SSLContext` successfully initializes with TLSv1.3

### Testing

All unit tests pass with JDK 25.  
The new TLSv1.3 test validates SSLContext creation without impacting any existing modules.

