### PR TITLE
Fix metrics scheduler lifecycle across rebases

### DIFF
--- a/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotScheduler.java
+++ b/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotScheduler.java
@@ -120,10 +120,9 @@ public final class MetricsSnapshotScheduler extends UnstartedPeriodicTaskCompone
                     throw new IllegalArgumentException(
                         "Requested interval " + intervalMillis + " must divide existing base interval " + existing.baseIntervalMillis);
                 }
-                List<ScheduleRegistration> registrations = existing.snapshotSchedules();
-                existing.teardown();
+                existing.retireForRebase();
                 MetricsSnapshotScheduler replacement = new MetricsSnapshotScheduler(root, intervalMillis);
-                replacement.restoreSchedules(registrations);
+                existing.transferSchedulesTo(replacement);
                 created[0] = replacement;
                 return replacement;
             }
@@ -149,6 +148,8 @@ public final class MetricsSnapshotScheduler extends UnstartedPeriodicTaskCompone
     private final ConcurrentHashMap<MetricsSnapshotConsumer, Long> consumerIntervals = new ConcurrentHashMap<>();
     private final Object scheduleLock = new Object();
     private final long baseIntervalMillis;
+    // Guarded by scheduleLock so registration transfer and unregister delegation are atomic.
+    private MetricsSnapshotScheduler successor;
 
     private MetricsSnapshotScheduler(NBComponent root, long intervalMillis) {
         super(root,
@@ -170,15 +171,22 @@ public final class MetricsSnapshotScheduler extends UnstartedPeriodicTaskCompone
         return schedulers.get(root);
     }
 
-    private List<ScheduleRegistration> snapshotSchedules() {
+    private List<ScheduleRegistration> snapshotSchedulesLocked() {
         List<ScheduleRegistration> registrations = new ArrayList<>();
-        synchronized (scheduleLock) {
-            for (Map.Entry<MetricsSnapshotConsumer, Long> entry : consumerIntervals.entrySet()) {
-                registrations.add(new ScheduleRegistration(entry.getValue(), entry.getKey()));
-            }
+        for (Map.Entry<MetricsSnapshotConsumer, Long> entry : consumerIntervals.entrySet()) {
+            registrations.add(new ScheduleRegistration(entry.getValue(), entry.getKey()));
         }
         registrations.sort((a, b) -> Long.compare(a.intervalMillis(), b.intervalMillis()));
         return registrations;
+    }
+
+    private void transferSchedulesTo(MetricsSnapshotScheduler replacement) {
+        synchronized (scheduleLock) {
+            replacement.restoreSchedules(snapshotSchedulesLocked());
+            successor = replacement;
+            consumerIntervals.clear();
+            scheduleNodes.clear();
+        }
     }
 
     private void restoreSchedules(List<ScheduleRegistration> registrations) {
@@ -209,13 +217,20 @@ public final class MetricsSnapshotScheduler extends UnstartedPeriodicTaskCompone
     }
 
     public void unregisterConsumer(MetricsSnapshotConsumer consumer) {
+        MetricsSnapshotScheduler delegate;
         synchronized (scheduleLock) {
-            Long interval = consumerIntervals.remove(consumer);
-            if (interval == null) {
+            delegate = successor;
+            if (delegate == null) {
+                Long interval = consumerIntervals.remove(consumer);
+                if (interval == null) {
+                    return;
+                }
+                rebuildScheduleTreeLocked();
                 return;
             }
-            rebuildScheduleTreeLocked();
         }
+        // Delegate after releasing scheduleLock so a chain of rebases never nests scheduler locks.
+        delegate.unregisterConsumer(consumer);
     }
 
     private void rebuildScheduleTreeLocked() {
@@ -325,13 +340,29 @@ public final class MetricsSnapshotScheduler extends UnstartedPeriodicTaskCompone
 
     @Override
     public void teardown() {
+        NBComponent root = detachFromParent();
+        if (root != null) {
+            schedulers.remove(root, this);
+        }
+        shutdownScheduler();
+    }
+
+    private void retireForRebase() {
+        detachFromParent();
+        super.teardown();
+    }
+
+    private NBComponent detachFromParent() {
         NBComponent parent = getParent();
         if (parent != null) {
             parent.detachChild(this);
         }
-        schedulers.values().removeIf(scheduler -> scheduler == this);
-        consumerIntervals.clear();
+        return parent;
+    }
+
+    private void shutdownScheduler() {
         synchronized (scheduleLock) {
+            consumerIntervals.clear();
             scheduleNodes.clear();
         }
         super.teardown();

--- a/nb-apis/nb-api/src/test/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotSchedulerTest.java
+++ b/nb-apis/nb-api/src/test/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotSchedulerTest.java
@@ -2,13 +2,13 @@ package io.nosqlbench.nb.api.engine.metrics;
 
 /*
  * Copyright (c) nosqlbench
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -152,6 +152,7 @@ public class MetricsSnapshotSchedulerTest {
         scheduler = MetricsSnapshotScheduler.register(root, 100L, baseSnapshots::add);
 
         assertThat(scheduler.getIntervalMillis()).isEqualTo(100L);
+        assertThat(MetricsSnapshotScheduler.lookup(root)).isSameAs(scheduler);
 
         scheduler.injectSnapshotForTesting(counterView(1, 100L));
         scheduler.injectSnapshotForTesting(counterView(2, 100L));
@@ -162,6 +163,20 @@ public class MetricsSnapshotSchedulerTest {
         MetricsView.PointSample sample = (MetricsView.PointSample) coarse.families().getFirst().samples().getFirst();
         assertThat(sample.value()).isEqualTo(3.0d);
         assertThat(coarse.intervalMillis()).isEqualTo(200L);
+    }
+
+    @Test
+    public void testUnregistersThroughRetiredScheduler() {
+        MetricsSnapshotScheduler.MetricsSnapshotConsumer coarseConsumer = coarseSnapshots::add;
+        MetricsSnapshotScheduler original = MetricsSnapshotScheduler.register(root, 200L, coarseConsumer);
+        scheduler = MetricsSnapshotScheduler.register(root, 100L, baseSnapshots::add);
+
+        original.unregisterConsumer(coarseConsumer);
+        scheduler.injectSnapshotForTesting(counterView(1, 100L));
+        scheduler.injectSnapshotForTesting(counterView(2, 100L));
+
+        assertThat(baseSnapshots).hasSize(2);
+        assertThat(coarseSnapshots).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR fixes two related lifecycle issues when `MetricsSnapshotScheduler` rebases to a faster sampling interval:

1. The replacement scheduler could disappear from the scheduler registry.
2. Consumers registered before the rebase could not unregister from the replacement scheduler.

## Problem

Consider two reporters registered in this order:

1. Reporter A requests a 200 ms interval, creating `Scheduler A`.
2. Reporter B later requests a 100 ms interval.
3. The scheduler rebases from 200 ms to 100 ms by replacing `Scheduler A` with `Scheduler B`.

Previously, the rebase called `teardown()` from inside `schedulers.compute(...)`. That teardown modified the **same** registry, so the newly created scheduler could be returned and started without remaining registered.

https://github.com/nosqlbench/nosqlbench/blob/4a5e567718416c7949f74695ccf9d9c0db6ef1ea/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotScheduler.java#L112-L124

https://github.com/nosqlbench/nosqlbench/blob/4a5e567718416c7949f74695ccf9d9c0db6ef1ea/nb-apis/nb-api/src/main/java/io/nosqlbench/nb/api/engine/metrics/MetricsSnapshotScheduler.java#L326-L332

There was also a stale-reference problem. Reporter A retained its original scheduler reference while its registration was copied to the replacement:

```text
Reporter A ──► Scheduler A (retired, no registrations)

Registry ────► Scheduler B (active)
               └─ Reporter A registration
```

When Reporter A closed, it called `unregisterConsumer()` on retired Scheduler A. The call became a no-op, leaving Reporter A registered with Scheduler B. The active scheduler could then continue invoking a closed reporter, potentially accessing closed CSV streams, SQLite connections, or other released resources.

## Solution

The rebase lifecycle now:

- Retires the old scheduler without modifying the registry entry currently being computed.
- Removes scheduler entries only during normal teardown, using a conditional key/value removal so an old scheduler cannot remove its replacement.
- Transfers registrations while holding `scheduleLock`.
- Publishes a successor reference atomically with the registration transfer.
- Delegates unregister calls from retired schedulers to their successors.
- Releases the old lock before delegation to avoid nested scheduler locks.

## Testing

The focused regression coverage verifies:

- `testRebasesWithSmallerInterval`
  - Ensure that `lookup(root)` returns the replacement scheduler.
- `testUnregistersThroughRetiredScheduler`
  - Ensure that an unregister call through the retired scheduler removes the consumer from the active replacement.

Validation completed successfully:

- `MetricsSnapshotSchedulerTest`: 9 tests passed.
- `MetricsReporterIntegrationTest`: 5 tests passed.
